### PR TITLE
refactor: centralize owner id parsing

### DIFF
--- a/src/events/messageDelete.js
+++ b/src/events/messageDelete.js
@@ -1,10 +1,6 @@
 const { Events, AuditLogEvent, PermissionsBitField, EmbedBuilder } = require('discord.js');
 const store = require('../utils/logChannelsStore');
-
-function parseOwnerIds() {
-  const raw = process.env.BOT_OWNER_IDS || '';
-  return raw.split(/[,\s]+/).map(s => s.trim()).filter(Boolean);
-}
+const { parseOwnerIds } = require('../utils/ownerIds');
 
 module.exports = {
   name: Events.MessageDelete,

--- a/src/utils/errorConsoleRelay.js
+++ b/src/utils/errorConsoleRelay.js
@@ -1,7 +1,4 @@
-function parseOwnerIds() {
-  const raw = process.env.BOT_OWNER_IDS || '';
-  return raw.split(/[\s,]+/).map(s => s.trim()).filter(Boolean);
-}
+const { parseOwnerIds } = require('./ownerIds');
 
 function formatArg(a) {
   try {

--- a/src/utils/modLogger.js
+++ b/src/utils/modLogger.js
@@ -1,10 +1,6 @@
 const { EmbedBuilder } = require('discord.js');
 const store = require('./modLogStore');
-
-function parseOwnerIds() {
-  const raw = process.env.BOT_OWNER_IDS || '';
-  return raw.split(/[\s,]+/).map(s => s.trim()).filter(Boolean);
-}
+const { parseOwnerIds } = require('./ownerIds');
 
 async function send(interaction, embed) {
   const guild = interaction.guild;

--- a/src/utils/ownerIds.js
+++ b/src/utils/ownerIds.js
@@ -1,0 +1,6 @@
+function parseOwnerIds() {
+  const raw = process.env.BOT_OWNER_IDS || '';
+  return raw.split(/[\s,]+/).map(s => s.trim()).filter(Boolean);
+}
+
+module.exports = { parseOwnerIds };

--- a/src/utils/securityLogger.js
+++ b/src/utils/securityLogger.js
@@ -1,11 +1,7 @@
 const { EmbedBuilder, PermissionsBitField } = require('discord.js');
 const logStore = require('./securityLogStore');
 const eventsStore = require('./securityEventsStore');
-
-function parseOwnerIds() {
-  const raw = process.env.BOT_OWNER_IDS || '';
-  return raw.split(/[\s,]+/).map(s => s.trim()).filter(Boolean);
-}
+const { parseOwnerIds } = require('./ownerIds');
 
 async function sendToChannelOrOwners(interaction, embed) {
   const guild = interaction.guild;


### PR DESCRIPTION
## Summary
- add shared owner ID parsing helper
- use shared helper in security, moderation, error relay, and message-delete logic

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ba419b64908331863d5d73162d7782