### PR TITLE
refactor: use async file operations for stores

### DIFF
--- a/src/commands/repeat.js
+++ b/src/commands/repeat.js
@@ -64,7 +64,7 @@ module.exports = {
       const channel = interaction.options.getChannel('channel') || interaction.channel;
       const seconds = interaction.options.getInteger('seconds') || 60;
       // We always save with min 60s; allow_mentions is applied at send-time by Discord anyway via content
-      const job = store.addJob(guildId, {
+      const job = await store.addJob(guildId, {
         channelId: channel.id,
         message,
         intervalMs: Math.max(60000, seconds * 1000),
@@ -75,13 +75,13 @@ module.exports = {
 
     if (sub === 'stop') {
       const id = interaction.options.getInteger('id', true);
-      const ok = store.removeJob(guildId, id);
+      const ok = await store.removeJob(guildId, id);
       try { scheduler.stopJob(guildId, id); } catch (_) {}
       return interaction.editReply({ content: ok ? `Stopped and removed job #${id}.` : `Job #${id} not found.` });
     }
 
     if (sub === 'list') {
-      const jobs = store.listJobs(guildId);
+      const jobs = await store.listJobs(guildId);
       if (!jobs.length) return interaction.editReply({ content: 'No repeat jobs configured.' });
       const lines = jobs.map(j => `#${j.id} ${j.enabled ? '[ON]' : '[OFF]'} every ${Math.round((j.intervalMs||60000)/1000)}s in <#${j.channelId}>: ${j.message.slice(0, 60)}`);
       return interaction.editReply({ content: lines.join('\n') });

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -3,7 +3,7 @@ const { Events, ActivityType } = require('discord.js');
 module.exports = {
   name: Events.ClientReady,
   once: true,
-  execute(client) {
+  async execute(client) {
     console.log(`${client.user.tag} is online and ready!`);
     console.log(`Serving ${client.guilds.cache.size} guilds`);
 
@@ -31,7 +31,7 @@ module.exports = {
     // Start auto-post scheduler for any saved repeat jobs
     try {
       const scheduler = require('../utils/autoPostScheduler');
-      scheduler.startAll(client);
+      await scheduler.startAll(client);
     } catch (e) {
       console.warn('Failed to start auto-post scheduler:', e?.message || e);
     }

--- a/src/utils/autoPostScheduler.js
+++ b/src/utils/autoPostScheduler.js
@@ -34,7 +34,7 @@ function startJob(client, guildId, job) {
   timers.set(k, handle);
 }
 
-function reloadGuild(client, guildId) {
+async function reloadGuild(client, guildId) {
   // stop existing
   for (const k of Array.from(timers.keys())) {
     if (k.startsWith(`${guildId}:`)) {
@@ -43,13 +43,13 @@ function reloadGuild(client, guildId) {
     }
   }
   // start all enabled
-  const jobs = store.listJobs(guildId);
+  const jobs = await store.listJobs(guildId);
   for (const job of jobs) startJob(client, guildId, job);
 }
 
-function startAll(client) {
+async function startAll(client) {
   const guilds = Array.from(client.guilds.cache.keys());
-  for (const gid of guilds) reloadGuild(client, gid);
+  for (const gid of guilds) await reloadGuild(client, gid);
 }
 
 module.exports = { startAll, reloadGuild, startJob, stopJob };


### PR DESCRIPTION
## Summary
- replace synchronous jail and autopost stores with async `fs.promises`
- batch file writes and log errors in store modules and scheduler
- update commands and ready handler to await new async APIs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba6e78f56483319bb8403dc56dbdc4