### PR TITLE
Log swallowed errors in commands and utilities

### DIFF
--- a/src/commands/autorespond.js
+++ b/src/commands/autorespond.js
@@ -99,7 +99,7 @@ module.exports = {
       try {
         const cfg = store.getGuildConfig(guildId);
         if (!cfg.enabled) store.setEnabled(guildId, true);
-      } catch (_) {}
+      } catch (err) { console.error('src/commands/autorespond.js', err); }
       return interaction.editReply({ content: `Added rule #${rule.id}: when ${match}${caseSensitive ? ' (case)' : ''} '${trigger}'${rule.channelId ? ` in <#${rule.channelId}>` : ''} -> reply '${reply}'.` });
     }
 

--- a/src/commands/ban.js
+++ b/src/commands/ban.js
@@ -60,7 +60,7 @@ module.exports = {
 
     // Try to fetch member for hierarchy checks if they are in the guild
     let targetMember = null;
-    try { targetMember = await interaction.guild.members.fetch(user.id); } catch (_) {}
+    try { targetMember = await interaction.guild.members.fetch(user.id); } catch (err) { console.error('src/commands/ban.js', err); }
 
     if (targetMember) {
       const meHigher = me.roles.highest.comparePositionTo(targetMember.roles.highest) > 0;
@@ -88,7 +88,7 @@ module.exports = {
         { name: 'Target', value: `${user.tag} (${user.id})`, inline: false },
         { name: 'Reason', value: reason, inline: false },
         { name: 'Prune days', value: String(pruneDays), inline: true },
-      ], 0xff0000); } catch (_) {}
+      ], 0xff0000); } catch (err) { console.error('src/commands/ban.js', err); }
     } catch (err) {
       await interaction.editReply({ content: `Failed to ban: ${err.message || 'Unknown error'}` });
     }

--- a/src/commands/chat.js
+++ b/src/commands/chat.js
@@ -69,7 +69,7 @@ module.exports = {
 
   async execute(interaction) {
     const isPrivate = !!interaction.options.getBoolean('private');
-    try { await interaction.deferReply({ ephemeral: isPrivate }); } catch (_) {}
+    try { await interaction.deferReply({ ephemeral: isPrivate }); } catch (err) { console.error('src/commands/chat.js', err); }
 
     if (!OPENAI_API_KEY) {
       return interaction.editReply('OpenAI API key not configured. Set OPENAI_API_KEY in your environment.');
@@ -99,7 +99,7 @@ module.exports = {
             const content = sanitize(m.content || '');
             if (content) messages.push({ role, content });
           }
-        } catch (_) {}
+        } catch (err) { console.error('src/commands/chat.js', err); }
       }
     }
 
@@ -122,7 +122,7 @@ module.exports = {
       const text = await resp.text();
       if (!resp.ok) {
         let msg = text;
-        try { msg = JSON.parse(text)?.error?.message || msg; } catch (_) {}
+        try { msg = JSON.parse(text)?.error?.message || msg; } catch (err) { console.error('src/commands/chat.js', err); }
         throw new Error(msg);
       }
 
@@ -137,14 +137,14 @@ module.exports = {
       await interaction.editReply(out.slice(0, 2000));
       for (let i = 2000; i < out.length; i += 2000) {
         const chunk = out.slice(i, i + 2000);
-        try { await interaction.followUp({ content: chunk, ephemeral: isPrivate }); } catch (_) {}
+        try { await interaction.followUp({ content: chunk, ephemeral: isPrivate }); } catch (err) { console.error('src/commands/chat.js', err); }
       }
     } catch (err) {
       const msg = err?.message || String(err);
       try {
         await interaction.editReply(`Chat failed: ${msg}`);
-      } catch (_) {
-        try { await interaction.followUp({ content: `Chat failed: ${msg}`, ephemeral: isPrivate }); } catch (_) {}
+      } catch (err) { console.error('src/commands/chat.js', err);
+        try { await interaction.followUp({ content: `Chat failed: ${msg}`, ephemeral: isPrivate }); } catch (err) { console.error('src/commands/chat.js', err); }
       }
     }
   },

--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -55,7 +55,7 @@ async function fetchStickerBufferByIdOrUrl(idOrUrl) {
                 const buf = await res.buffer();
                 if (buf && buf.length > 0) return { buffer: buf, sourceUrl: url };
             }
-        } catch (_) {
+        } catch (err) { console.error('src/commands/clone.js', err);
             // try next
         }
     }

--- a/src/commands/cloneall.js
+++ b/src/commands/cloneall.js
@@ -60,11 +60,11 @@ module.exports = {
 
     const me = interaction.guild.members.me;
     if (!me.permissions.has(PermissionsBitField.Flags.ManageGuildExpressions)) {
-      try { await logger.logPermissionDenied(interaction, 'cloneall', 'Bot missing Manage Emojis and Stickers'); } catch (_) {}
+      try { await logger.logPermissionDenied(interaction, 'cloneall', 'Bot missing Manage Emojis and Stickers'); } catch (err) { console.error('src/commands/cloneall.js', err); }
       return interaction.reply({ content: 'I need the Manage Emojis and Stickers permission.', ephemeral: true });
     }
     if (!interaction.member.permissions?.has(PermissionsBitField.Flags.ManageGuildExpressions)) {
-      try { await logger.logPermissionDenied(interaction, 'cloneall', 'User missing Manage Emojis and Stickers'); } catch (_) {}
+      try { await logger.logPermissionDenied(interaction, 'cloneall', 'User missing Manage Emojis and Stickers'); } catch (err) { console.error('src/commands/cloneall.js', err); }
       return interaction.reply({ content: 'You need Manage Emojis and Stickers to use this command.', ephemeral: true });
     }
 
@@ -80,7 +80,7 @@ module.exports = {
 
     let sourceGuild = interaction.client.guilds.cache.get(sourceId);
     if (!sourceGuild) {
-      try { sourceGuild = await interaction.client.guilds.fetch(sourceId); } catch (_) {}
+      try { sourceGuild = await interaction.client.guilds.fetch(sourceId); } catch (err) { console.error('src/commands/cloneall.js', err); }
     }
     if (!sourceGuild) {
       return interaction.editReply({ content: 'I am not in that server or the ID is invalid.' });

--- a/src/commands/createrole.js
+++ b/src/commands/createrole.js
@@ -78,7 +78,7 @@ module.exports = {
         position = Math.max(1, Math.min(position, maxPosition));
         try {
           await role.setPosition(position);
-        } catch (_) {
+        } catch (err) { console.error('src/commands/createrole.js', err);
           // If setting position fails, keep role created and continue
         }
       }
@@ -88,7 +88,7 @@ module.exports = {
         { name: 'Color', value: String(color || 'default'), inline: true },
         { name: 'Hoist', value: String(hoist), inline: true },
         { name: 'Mentionable', value: String(mentionable), inline: true },
-      ]); } catch (_) {}
+      ]); } catch (err) { console.error('src/commands/createrole.js', err); }
       return interaction.reply({ content: `Created role ${role.toString()}${position ? ` at position ${role.position}` : ''}.`, ephemeral: true });
     } catch (err) {
       return interaction.reply({ content: `Failed to create role: ${err.message || 'Unknown error'}`, ephemeral: true });

--- a/src/commands/dmdiag.js
+++ b/src/commands/dmdiag.js
@@ -38,7 +38,7 @@ module.exports = {
 
     // Restrict to bot owners only
     if (!isOwner(interaction.user.id)) {
-      try { await logger.logPermissionDenied(interaction, 'dmdiag', 'User is not a bot owner'); } catch (_) {}
+      try { await logger.logPermissionDenied(interaction, 'dmdiag', 'User is not a bot owner'); } catch (err) { console.error('src/commands/dmdiag.js', err); }
       return interaction.reply({ content: 'This command is restricted to bot owners.', ephemeral: true });
     }
 
@@ -75,7 +75,7 @@ module.exports = {
       let members;
       try {
         members = await interaction.guild.members.fetch();
-      } catch (_) {
+      } catch (err) { console.error('src/commands/dmdiag.js', err);
         members = interaction.guild.members.cache;
       }
       const list = members.filter(m => m.roles.cache.has(role.id) && !m.user.bot).first(limit);

--- a/src/commands/enlarge.js
+++ b/src/commands/enlarge.js
@@ -121,7 +121,7 @@ async function fetchStickerBufferByIdOrUrl(idOrUrl) {
         const buf = await res.buffer();
         if (buf && buf.length > 0) return { buffer: buf, sourceUrl: url };
       }
-    } catch (_) {
+    } catch (err) { console.error('src/commands/enlarge.js', err);
       // continue
     }
   }
@@ -172,12 +172,12 @@ module.exports = {
     try {
       await interaction.reply({ content: 'Fetching media…' });
       acknowledged = true;
-    } catch (_) {
+    } catch (err) { console.error('src/commands/enlarge.js', err);
       try {
         if (interaction.channel?.send) {
           channelMsg = await interaction.channel.send('Fetching media…');
         }
-      } catch (_) {
+      } catch (err) { console.error('src/commands/enlarge.js', err);
         // ignore; we will try again later
       }
     }

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -69,7 +69,7 @@ function buildEmbed(categoryName, includeOwner, guildId) {
   try {
     const { applyDefaultColour } = require('../utils/guildColourStore');
     applyDefaultColour(embed, guildId);
-  } catch (_) {}
+  } catch (err) { console.error('src/commands/help.js', err); }
 
   if (categoryName && categories[categoryName]) {
     if (categoryName === 'Owner Only' && !includeOwner) {
@@ -123,12 +123,12 @@ module.exports = {
     const embed = buildEmbed(cat, owner, interaction.guildId);
     try {
       await interaction.reply({ embeds: [embed] });
-    } catch (_) {
+    } catch (err) { console.error('src/commands/help.js', err);
       try {
         if (interaction.channel && interaction.channel.send) {
           await interaction.channel.send({ embeds: [embed] });
         }
-      } catch (_) {}
+      } catch (err) { console.error('src/commands/help.js', err); }
     }
   },
 };

--- a/src/commands/isolate.js
+++ b/src/commands/isolate.js
@@ -49,7 +49,7 @@ module.exports = {
     const owners = raw.split(/[\s,]+/).map(s => s.trim()).filter(Boolean);
     const isOwner = owners.includes(String(interaction.user.id));
     if (!isOwner) {
-      try { await logger.logPermissionDenied(interaction, 'wraith', 'User is not a bot owner'); } catch (_) {}
+      try { await logger.logPermissionDenied(interaction, 'wraith', 'User is not a bot owner'); } catch (err) { console.error('src/commands/isolate.js', err); }
       return interaction.reply({ content: 'This command is restricted to bot owners.', ephemeral: true });
     }
 
@@ -67,7 +67,7 @@ module.exports = {
       }
 
       let member;
-      try { member = await interaction.guild.members.fetch(target.id); } catch (_) {}
+      try { member = await interaction.guild.members.fetch(target.id); } catch (err) { console.error('src/commands/isolate.js', err); }
       if (!member) return interaction.reply({ content: 'That user is not in this server.', ephemeral: true });
 
       const durationStr = interaction.options.getString('duration');
@@ -132,7 +132,7 @@ module.exports = {
               hiddenOverwrites.push({ channelId: ch.id, existed: false });
             }
             await ch.permissionOverwrites.edit(member.id, { ViewChannel: false, reason: `Wraith hide by ${interaction.user.tag}` });
-          } catch (_) { /* ignore individual channel failures */ }
+          } catch (err) { console.error('src/commands/isolate.js', err); /* ignore individual channel failures */ }
         }
       }
 
@@ -143,7 +143,7 @@ module.exports = {
       const sendOne = async () => {
         try {
           await channel.send({ content: text });
-        } catch (_) { /* ignore send errors during loop */ }
+        } catch (err) { console.error('src/commands/isolate.js', err); /* ignore send errors during loop */ }
       };
 
       // Immediately send first message
@@ -154,13 +154,13 @@ module.exports = {
         if (stopAt && Date.now() >= stopAt) {
           clearInterval(intervalId);
           activeIsolations.delete(k);
-          try { await channel.send({ content: 'Stopping.' }); } catch (_) {}
+          try { await channel.send({ content: 'Stopping.' }); } catch (err) { console.error('src/commands/isolate.js', err); }
           return;
         }
         if (sent >= maxMessages) {
           clearInterval(intervalId);
           activeIsolations.delete(k);
-          try { await channel.send({ content: 'Reached max messages. Stopping.' }); } catch (_) {}
+          try { await channel.send({ content: 'Reached max messages. Stopping.' }); } catch (err) { console.error('src/commands/isolate.js', err); }
           return;
         }
         sent++;
@@ -180,14 +180,14 @@ module.exports = {
         return interaction.reply({ content: `No active isolation found for <@${target.id}>.`, ephemeral: true });
       }
       activeIsolations.delete(k);
-      try { clearInterval(rec.intervalId); } catch (_) {}
+      try { clearInterval(rec.intervalId); } catch (err) { console.error('src/commands/isolate.js', err); }
 
       let channel = null;
-      try { channel = await interaction.guild.channels.fetch(rec.channelId); } catch (_) {}
+      try { channel = await interaction.guild.channels.fetch(rec.channelId); } catch (err) { console.error('src/commands/isolate.js', err); }
       if (channel && del !== false) {
-        try { await channel.delete('Isolation stopped by owner'); } catch (_) {}
+        try { await channel.delete('Isolation stopped by owner'); } catch (err) { console.error('src/commands/isolate.js', err); }
       } else if (channel) {
-        try { await channel.send({ content: 'Isolation stopped by owner.' }); } catch (_) {}
+        try { await channel.send({ content: 'Isolation stopped by owner.' }); } catch (err) { console.error('src/commands/isolate.js', err); }
       }
 
       // Restore hidden channels if applicable
@@ -202,7 +202,7 @@ module.exports = {
             } else {
               await ch.permissionOverwrites.delete(memberId, 'Restore after wraith');
             }
-          } catch (_) { /* ignore individual failures */ }
+          } catch (err) { console.error('src/commands/isolate.js', err); /* ignore individual failures */ }
         }
       }
       return interaction.reply({ content: `Stopped isolation for <@${target.id}>${channel ? (del !== false ? ' and deleted channel.' : ' and kept channel.') : '.'}`, ephemeral: true });

--- a/src/commands/jail.js
+++ b/src/commands/jail.js
@@ -20,7 +20,7 @@ async function safeRemoveAllRoles(member, exceptIds = []) {
     try {
       await member.roles.remove(role, 'Jail: removing roles');
       removed.push(role.id);
-    } catch (_) {}
+    } catch (err) { console.error('src/commands/jail.js', err); }
   }
   return removed;
 }
@@ -114,13 +114,13 @@ module.exports = {
 
       let jailRole = interaction.guild.roles.cache.get(config.jailRoleId);
       if (!jailRole) {
-        try { jailRole = await interaction.guild.roles.fetch(config.jailRoleId); } catch (_) {}
+        try { jailRole = await interaction.guild.roles.fetch(config.jailRoleId); } catch (err) { console.error('src/commands/jail.js', err); }
       }
       if (!jailRole) return interaction.reply({ content: 'Configured jail role not found. Set it again with /jail config.', ephemeral });
       if (me.roles.highest.comparePositionTo(jailRole) <= 0) return interaction.reply({ content: 'My highest role must be above the jail role.', ephemeral });
 
       let member;
-      try { member = await interaction.guild.members.fetch(targetUser.id); } catch (_) {}
+      try { member = await interaction.guild.members.fetch(targetUser.id); } catch (err) { console.error('src/commands/jail.js', err); }
       if (!member) return interaction.reply({ content: 'That user is not in this server.', ephemeral });
       if (member.id === interaction.user.id) return interaction.reply({ content: 'You cannot jail yourself.', ephemeral });
       if (interaction.guild.ownerId !== interaction.user.id && interaction.member.roles.highest.comparePositionTo(member.roles.highest) <= 0) {
@@ -157,20 +157,20 @@ module.exports = {
       const config = store.getConfig(interaction.guild.id);
       if (!config.jailRoleId) return interaction.reply({ content: 'Set a jail role first with /jail config.', ephemeral });
       let member;
-      try { member = await interaction.guild.members.fetch(targetUser.id); } catch (_) {}
+      try { member = await interaction.guild.members.fetch(targetUser.id); } catch (err) { console.error('src/commands/jail.js', err); }
       if (!member) return interaction.reply({ content: 'That user is not in this server.', ephemeral });
       const rec = store.getJailed(interaction.guild.id, member.id);
       const prevRoles = rec?.roles || [];
 
       // Remove jail role
-      try { await member.roles.remove(config.jailRoleId, 'Unjail'); } catch (_) {}
+      try { await member.roles.remove(config.jailRoleId, 'Unjail'); } catch (err) { console.error('src/commands/jail.js', err); }
       // Restore previous roles that still exist and are below bot
       const meTop = me.roles.highest;
       for (const roleId of prevRoles) {
         const role = interaction.guild.roles.cache.get(roleId);
         if (!role || role.managed) continue;
         if (meTop.comparePositionTo(role) <= 0) continue;
-        try { await member.roles.add(role, 'Unjail: restoring previous roles'); } catch (_) {}
+        try { await member.roles.add(role, 'Unjail: restoring previous roles'); } catch (err) { console.error('src/commands/jail.js', err); }
       }
       store.removeJailed(interaction.guild.id, member.id);
       return interaction.reply({ content: `Unjailed ${member.user.tag}.`, ephemeral });

--- a/src/commands/joins.js
+++ b/src/commands/joins.js
@@ -154,7 +154,7 @@ module.exports = {
             try {
               store.addEvent(interaction.guildId, id, isJoin ? 'join' : 'leave', msg.createdTimestamp || Date.now(), { messageId: msg.id, sourceChannelId: channel.id });
               if (isJoin) joins++; else leaves++;
-            } catch (_) {}
+            } catch (err) { console.error('src/commands/joins.js', err); }
           }
         }
         if (msgs.size < remaining) break; // no more messages

--- a/src/commands/kick.js
+++ b/src/commands/kick.js
@@ -53,7 +53,7 @@ module.exports = {
     let memberToKick;
     try {
       memberToKick = await interaction.guild.members.fetch(user.id);
-    } catch (_) {
+    } catch (err) { console.error('src/commands/kick.js', err);
       return interaction.editReply({ content: 'That user is not in this server.' });
     }
 
@@ -79,7 +79,7 @@ module.exports = {
       try { await modlog.log(interaction, 'User Kicked', [
         { name: 'Target', value: `${user.tag} (${user.id})`, inline: false },
         { name: 'Reason', value: reason, inline: false },
-      ], 0xffa500); } catch (_) {}
+      ], 0xffa500); } catch (err) { console.error('src/commands/kick.js', err); }
     } catch (err) {
       await interaction.editReply({ content: `Failed to kick: ${err.message || 'Unknown error'}` });
     }

--- a/src/commands/mute.js
+++ b/src/commands/mute.js
@@ -79,7 +79,7 @@ module.exports = {
     let memberToMute;
     try {
       memberToMute = await interaction.guild.members.fetch(user.id);
-    } catch (_) {
+    } catch (err) { console.error('src/commands/mute.js', err);
       return interaction.editReply({ content: 'That user is not in this server.' });
     }
 
@@ -105,7 +105,7 @@ module.exports = {
         { name: 'Target', value: `${user.tag} (${user.id})`, inline: false },
         { name: 'Duration', value: durationStr, inline: true },
         { name: 'Reason', value: reason, inline: false },
-      ], 0xffcc00); } catch (_) {}
+      ], 0xffcc00); } catch (err) { console.error('src/commands/mute.js', err); }
     } catch (err) {
       await interaction.editReply({ content: `Failed to mute: ${err.message || 'Unknown error'}` });
     }

--- a/src/commands/purge.js
+++ b/src/commands/purge.js
@@ -58,7 +58,7 @@ module.exports = {
         { name: 'Channel', value: `<#${channel.id}> (${channel.id})`, inline: true },
         { name: 'Requested', value: String(amount), inline: true },
         { name: 'Deleted', value: String(count), inline: true },
-      ], 0x2f3136); } catch (_) {}
+      ], 0x2f3136); } catch (err) { console.error('src/commands/purge.js', err); }
     } catch (err) {
       await interaction.editReply({ content: `Failed to purge: ${err.message || 'Unknown error'}` });
     }

--- a/src/commands/reactionrole.js
+++ b/src/commands/reactionrole.js
@@ -99,7 +99,7 @@ module.exports = {
     try {
       const { applyDefaultColour } = require('../utils/guildColourStore');
       applyDefaultColour(embed, interaction.guildId);
-    } catch (_) {
+    } catch (err) { console.error('src/commands/reactionrole.js', err);
       // fallback stays uncoloured if util import fails
     }
 

--- a/src/commands/removebg.js
+++ b/src/commands/removebg.js
@@ -21,7 +21,7 @@ module.exports = {
     async execute(interaction) {
         await interaction.deferReply();
 
-        try { console.log(`[removebg] invoked by ${interaction.user?.id} in ${interaction.guild?.id}`); } catch (_) {}
+        try { console.log(`[removebg] invoked by ${interaction.user?.id} in ${interaction.guild?.id}`); } catch (err) { console.error('src/commands/removebg.js', err); }
 
         if (!REMOVE_BG_API_KEY) {
             await interaction.editReply('RemoveBG API key is not configured. Set REMOVE_BG_API_KEY in your environment.');
@@ -71,7 +71,7 @@ module.exports = {
                 try {
                     const data = JSON.parse(text);
                     msg = data?.errors?.[0]?.title || data?.errors?.[0]?.detail || msg;
-                } catch (_) {}
+                } catch (err) { console.error('src/commands/removebg.js', err); }
                 console.log(`[removebg] error status=${response.status} body=${text?.slice(0,400)}`);
                 throw new Error(msg);
             }
@@ -82,13 +82,13 @@ module.exports = {
             try {
                 await interaction.editReply({ content: 'Background removed:', files: [attachment] });
             } catch (e) {
-                try { await interaction.followUp({ content: 'Background removed:', files: [attachment] }); } catch (_) {}
+                try { await interaction.followUp({ content: 'Background removed:', files: [attachment] }); } catch (err) { console.error('src/commands/removebg.js', err); }
             }
         } catch (error) {
             try {
                 await interaction.editReply(`Failed to remove background: ${error.message}`);
-            } catch (_) {
-                try { await interaction.followUp({ content: `Failed to remove background: ${error.message}` }); } catch (_) {}
+            } catch (err) { console.error('src/commands/removebg.js', err);
+                try { await interaction.followUp({ content: `Failed to remove background: ${error.message}` }); } catch (err) { console.error('src/commands/removebg.js', err); }
             }
         }
     },

--- a/src/commands/repeat.js
+++ b/src/commands/repeat.js
@@ -69,14 +69,14 @@ module.exports = {
         message,
         intervalMs: Math.max(60000, seconds * 1000),
       });
-      try { scheduler.startJob(interaction.client, guildId, job); } catch (_) {}
+      try { scheduler.startJob(interaction.client, guildId, job); } catch (err) { console.error('src/commands/repeat.js', err); }
       return interaction.editReply({ content: `Repeat job #${job.id} started in ${channel} every ${Math.max(60, seconds)} seconds.` });
     }
 
     if (sub === 'stop') {
       const id = interaction.options.getInteger('id', true);
       const ok = store.removeJob(guildId, id);
-      try { scheduler.stopJob(guildId, id); } catch (_) {}
+      try { scheduler.stopJob(guildId, id); } catch (err) { console.error('src/commands/repeat.js', err); }
       return interaction.editReply({ content: ok ? `Stopped and removed job #${id}.` : `Job #${id} not found.` });
     }
 

--- a/src/commands/role.js
+++ b/src/commands/role.js
@@ -76,8 +76,7 @@ module.exports = {
     let member;
     try {
       member = await interaction.guild.members.fetch(user.id);
-    } catch (_) {
-      return interaction.editReply({ content: 'That user is not in this server.' });
+    } catch (err) { console.error('src/commands/role.js', err); return interaction.editReply({ content: 'That user is not in this server.' });
     }
 
     try {
@@ -90,7 +89,7 @@ module.exports = {
           { name: 'Member', value: `${user.tag} (${user.id})`, inline: false },
           { name: 'Role', value: `${role} (${role.id})`, inline: false },
           { name: 'Reason', value: reasonRaw, inline: false },
-        ]); } catch (_) {}
+        ]); } catch (err) { console.error('src/commands/role.js', err); }
         return interaction.editReply({ content: `Added ${role.toString()} to ${user.tag}.` });
       } else if (sub === 'remove') {
         if (!member.roles.cache.has(role.id)) {
@@ -101,7 +100,7 @@ module.exports = {
           { name: 'Member', value: `${user.tag} (${user.id})`, inline: false },
           { name: 'Role', value: `${role} (${role.id})`, inline: false },
           { name: 'Reason', value: reasonRaw, inline: false },
-        ]); } catch (_) {}
+        ]); } catch (err) { console.error('src/commands/role.js', err); }
         return interaction.editReply({ content: `Removed ${role.toString()} from ${user.tag}.` });
       }
     } catch (err) {

--- a/src/commands/summarize.js
+++ b/src/commands/summarize.js
@@ -152,7 +152,7 @@ module.exports = {
       const text = await resp.text();
       if (!resp.ok) {
         let msg = text;
-        try { msg = JSON.parse(text)?.error?.message || msg; } catch (_) {}
+        try { msg = JSON.parse(text)?.error?.message || msg; } catch (err) { console.error('src/commands/summarize.js', err); }
         throw new Error(msg);
       }
       const data = JSON.parse(text);
@@ -168,14 +168,14 @@ module.exports = {
       await interaction.editReply('Summary is long; sending in parts below:');
       for (let i = 0; i < finalMsg.length; i += 2000) {
         const chunk = finalMsg.slice(i, i + 2000);
-        try { await interaction.followUp({ content: chunk }); } catch (_) {}
+        try { await interaction.followUp({ content: chunk }); } catch (err) { console.error('src/commands/summarize.js', err); }
       }
     } catch (err) {
       const msg = err?.message || String(err);
       try {
         await interaction.editReply(`Failed to summarize: ${msg}`);
-      } catch (_) {
-        try { await interaction.followUp({ content: `Failed to summarize: ${msg}` }); } catch (_) {}
+      } catch (err) { console.error('src/commands/summarize.js', err);
+        try { await interaction.followUp({ content: `Failed to summarize: ${msg}` }); } catch (err) { console.error('src/commands/summarize.js', err); }
       }
     }
   },

--- a/src/commands/verify.js
+++ b/src/commands/verify.js
@@ -72,7 +72,7 @@ module.exports = {
       try {
         const { applyDefaultColour } = require('../utils/guildColourStore');
         applyDefaultColour(embed, interaction.guildId);
-      } catch (_) {}
+      } catch (err) { console.error('src/commands/verify.js', err); }
 
       const button = new ButtonBuilder()
         .setCustomId('verify:go')
@@ -136,7 +136,7 @@ module.exports = {
       try {
         const { applyDefaultColour } = require('../utils/guildColourStore');
         applyDefaultColour(embed, interaction.guildId);
-      } catch (_) {}
+      } catch (err) { console.error('src/commands/verify.js', err); }
       const button = new ButtonBuilder()
         .setCustomId('verify:go')
         .setLabel(cfg.label || 'Verify')

--- a/src/commands/welcome.js
+++ b/src/commands/welcome.js
@@ -15,9 +15,9 @@ function buildEmbedFromFields(fields, guildId) {
   if (image) embed.setImage(image);
   if (footer) embed.setFooter({ text: footer });
   // Prefer guild default colour; if user specified a colour string, try to apply it as fallback
-  try { applyDefaultColour(embed, guildId); } catch (_) {}
+  try { applyDefaultColour(embed, guildId); } catch (err) { console.error('src/commands/welcome.js', err); }
   if (color) {
-    try { embed.setColor(color); } catch (_) {}
+    try { embed.setColor(color); } catch (err) { console.error('src/commands/welcome.js', err); }
   }
   return embed;
 }
@@ -71,7 +71,7 @@ module.exports = {
       const channel = await interaction.guild.channels.fetch(cfg.channelId).catch(() => null);
       if (!channel) return interaction.reply({ content: 'Saved channel not found. Re-run setup.', ephemeral: true });
       const preview = EmbedBuilder.from(cfg.embed);
-      try { await channel.send({ content: `Welcome, ${interaction.user}!`, embeds: [preview] }); } catch (_) {}
+      try { await channel.send({ content: `Welcome, ${interaction.user}!`, embeds: [preview] }); } catch (err) { console.error('src/commands/welcome.js', err); }
       return interaction.reply({ content: `Sent a test welcome to ${channel}.`, ephemeral: true });
     }
 

--- a/src/events/guildMemberAdd.js
+++ b/src/events/guildMemberAdd.js
@@ -8,7 +8,7 @@ module.exports = {
     async execute(member) {
         try {
             // Record join
-            try { jlStore.addEvent(member.guild.id, member.id, 'join', Date.now()); } catch (_) {}
+            try { jlStore.addEvent(member.guild.id, member.id, 'join', Date.now()); } catch (err) { console.error('src/events/guildMemberAdd.js', err); }
 
             const roleIds = store.getGuildRoles(member.guild.id);
             if (!roleIds.length) return;

--- a/src/events/guildMemberRemove.js
+++ b/src/events/guildMemberRemove.js
@@ -18,7 +18,7 @@ module.exports = {
           const ban = recent.find(e => e.action === AuditLogEvent.MemberBanAdd && e.target?.id === member.id);
           if (kick) reason = 'kick';
           if (ban) reason = 'ban';
-        } catch (_) { /* ignore */ }
+        } catch (err) { console.error('src/events/guildMemberRemove.js', err); /* ignore */ }
       }
       jlStore.addEvent(guild.id, member.id, 'leave', Date.now(), { reason });
     } catch (e) {

--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -15,7 +15,7 @@ module.exports = {
                 try {
                     const logger = require('../utils/securityLogger');
                     await logger.logMissingCommand(interaction);
-                } catch (_) {}
+                } catch (err) { console.error('src/events/interactionCreate.js', err); }
                 return;
             }
 
@@ -56,13 +56,13 @@ module.exports = {
                 if (!interaction.inGuild()) return;
                 const me = interaction.guild.members.me;
                 if (!me.permissions.has(PermissionsBitField.Flags.ManageRoles)) {
-                    try { await interaction.reply({ content: 'I need Manage Roles to update your roles.', ephemeral: true }); } catch (_) {}
+                    try { await interaction.reply({ content: 'I need Manage Roles to update your roles.', ephemeral: true }); } catch (err) { console.error('src/events/interactionCreate.js', err); }
                     return;
                 }
                 let member;
-                try { member = await interaction.guild.members.fetch(interaction.user.id); } catch (_) {}
+                try { member = await interaction.guild.members.fetch(interaction.user.id); } catch (err) { console.error('src/events/interactionCreate.js', err); }
                 if (!member) {
-                    try { await interaction.reply({ content: 'Could not fetch your member data.', ephemeral: true }); } catch (_) {}
+                    try { await interaction.reply({ content: 'Could not fetch your member data.', ephemeral: true }); } catch (err) { console.error('src/events/interactionCreate.js', err); }
                     return;
                 }
 
@@ -101,31 +101,31 @@ module.exports = {
 
                 const cfg = verifyStore.get(interaction.guild.id);
                 if (!cfg) {
-                    try { await interaction.reply({ content: 'Verification is not configured on this server.', ephemeral: true }); } catch (_) {}
+                    try { await interaction.reply({ content: 'Verification is not configured on this server.', ephemeral: true }); } catch (err) { console.error('src/events/interactionCreate.js', err); }
                     return;
                 }
 
                 let role = null;
-                try { role = await interaction.guild.roles.fetch(cfg.roleId); } catch (_) {}
+                try { role = await interaction.guild.roles.fetch(cfg.roleId); } catch (err) { console.error('src/events/interactionCreate.js', err); }
                 if (!role) {
-                    try { await interaction.reply({ content: 'The verification role no longer exists. Please contact an admin.', ephemeral: true }); } catch (_) {}
+                    try { await interaction.reply({ content: 'The verification role no longer exists. Please contact an admin.', ephemeral: true }); } catch (err) { console.error('src/events/interactionCreate.js', err); }
                     return;
                 }
 
                 const me = interaction.guild.members.me;
                 if (!me.permissions.has(PermissionsBitField.Flags.ManageRoles)) {
-                    try { await interaction.reply({ content: 'I am missing Manage Roles.', ephemeral: true }); } catch (_) {}
+                    try { await interaction.reply({ content: 'I am missing Manage Roles.', ephemeral: true }); } catch (err) { console.error('src/events/interactionCreate.js', err); }
                     return;
                 }
                 if (role.managed || me.roles.highest.comparePositionTo(role) <= 0) {
-                    try { await interaction.reply({ content: 'I cannot assign the verification role due to role hierarchy.', ephemeral: true }); } catch (_) {}
+                    try { await interaction.reply({ content: 'I cannot assign the verification role due to role hierarchy.', ephemeral: true }); } catch (err) { console.error('src/events/interactionCreate.js', err); }
                     return;
                 }
 
                 let member = null;
-                try { member = await interaction.guild.members.fetch(interaction.user.id); } catch (_) {}
+                try { member = await interaction.guild.members.fetch(interaction.user.id); } catch (err) { console.error('src/events/interactionCreate.js', err); }
                 if (!member) {
-                    try { await interaction.reply({ content: 'Could not fetch your member data.', ephemeral: true }); } catch (_) {}
+                    try { await interaction.reply({ content: 'Could not fetch your member data.', ephemeral: true }); } catch (err) { console.error('src/events/interactionCreate.js', err); }
                     return;
                 }
 
@@ -137,15 +137,15 @@ module.exports = {
                     if (acctDays < minDays) {
                         try {
                             await interaction.reply({ content: `Your account must be at least ${minDays} day(s) old to verify. Current: ${acctDays} day(s).`, ephemeral: true });
-                        } catch (_) {}
-                        try { await securityLogger.logPermissionDenied(interaction, 'verify', 'Account below minimum age'); } catch (_) {}
+                        } catch (err) { console.error('src/events/interactionCreate.js', err); }
+                        try { await securityLogger.logPermissionDenied(interaction, 'verify', 'Account below minimum age'); } catch (err) { console.error('src/events/interactionCreate.js', err); }
                         return;
                     }
                 }
 
                 // Already verified
                 if (member.roles.cache.has(role.id)) {
-                    try { await interaction.reply({ content: 'You are already verified.', ephemeral: true }); } catch (_) {}
+                    try { await interaction.reply({ content: 'You are already verified.', ephemeral: true }); } catch (err) { console.error('src/events/interactionCreate.js', err); }
                     return;
                 }
 
@@ -173,8 +173,8 @@ module.exports = {
                 modal.addComponents(row);
                 try {
                     await interaction.showModal(modal);
-                } catch (_) {
-                    try { await interaction.reply({ content: 'Could not open verification challenge. Try again.', ephemeral: true }); } catch (_) {}
+                } catch (err) { console.error('src/events/interactionCreate.js', err);
+                    try { await interaction.reply({ content: 'Could not open verification challenge. Try again.', ephemeral: true }); } catch (err) { console.error('src/events/interactionCreate.js', err); }
                 }
                 return;
             }
@@ -188,9 +188,9 @@ module.exports = {
                 const parts = interaction.customId.split(':');
                 const channelId = parts[2];
                 let channel = null;
-                try { channel = await interaction.guild.channels.fetch(channelId); } catch (_) {}
+                try { channel = await interaction.guild.channels.fetch(channelId); } catch (err) { console.error('src/events/interactionCreate.js', err); }
                 if (!channel) {
-                    try { await interaction.reply({ content: 'Saved channel not found. Re-run /welcome setup.', ephemeral: true }); } catch (_) {}
+                    try { await interaction.reply({ content: 'Saved channel not found. Re-run /welcome setup.', ephemeral: true }); } catch (err) { console.error('src/events/interactionCreate.js', err); }
                     return;
                 }
 
@@ -208,8 +208,8 @@ module.exports = {
                     if (description) embed.setDescription(description);
                     if (image) embed.setImage(image);
                     if (footer) embed.setFooter({ text: footer });
-                    try { applyDefaultColour(embed, interaction.guildId); } catch (_) {}
-                    if (color) { try { embed.setColor(color); } catch (_) {} }
+                    try { applyDefaultColour(embed, interaction.guildId); } catch (err) { console.error('src/events/interactionCreate.js', err); }
+                    if (color) { try { embed.setColor(color); } catch (err) { console.error('src/events/interactionCreate.js', err); } }
 
                     // Save configuration
                     welcomeStore.set(interaction.guildId, { channelId, embed: embed.toJSON() });
@@ -225,7 +225,7 @@ module.exports = {
                 if (!interaction.inGuild()) return;
                 const sess = verifySession.get(interaction.guild.id, interaction.user.id);
                 if (!sess) {
-                    try { await interaction.reply({ content: 'Verification session expired. Press Verify again.', ephemeral: true }); } catch (_) {}
+                    try { await interaction.reply({ content: 'Verification session expired. Press Verify again.', ephemeral: true }); } catch (err) { console.error('src/events/interactionCreate.js', err); }
                     return;
                 }
                 const answer = (interaction.fields.getTextInputValue('verify:answer') || '').trim().toUpperCase();
@@ -234,10 +234,10 @@ module.exports = {
                 if (answer !== expect) {
                     const after = verifySession.consumeAttempt(interaction.guild.id, interaction.user.id);
                     if (!after || after.attempts <= 0) {
-                        try { await interaction.reply({ content: 'Incorrect code. Session ended. Press Verify to try again.', ephemeral: true }); } catch (_) {}
+                        try { await interaction.reply({ content: 'Incorrect code. Session ended. Press Verify to try again.', ephemeral: true }); } catch (err) { console.error('src/events/interactionCreate.js', err); }
                         return;
                     }
-                    try { await interaction.reply({ content: `Incorrect code. Attempts left: ${after.attempts}. Press Verify to try again.`, ephemeral: true }); } catch (_) {}
+                    try { await interaction.reply({ content: `Incorrect code. Attempts left: ${after.attempts}. Press Verify to try again.`, ephemeral: true }); } catch (err) { console.error('src/events/interactionCreate.js', err); }
                     return;
                 }
 
@@ -245,27 +245,27 @@ module.exports = {
                 verifySession.clear(interaction.guild.id, interaction.user.id);
 
                 let role = null;
-                try { role = await interaction.guild.roles.fetch(sess.roleId); } catch (_) {}
+                try { role = await interaction.guild.roles.fetch(sess.roleId); } catch (err) { console.error('src/events/interactionCreate.js', err); }
                 if (!role) {
-                    try { await interaction.reply({ content: 'Verification role was removed. Contact an admin.', ephemeral: true }); } catch (_) {}
+                    try { await interaction.reply({ content: 'Verification role was removed. Contact an admin.', ephemeral: true }); } catch (err) { console.error('src/events/interactionCreate.js', err); }
                     return;
                 }
                 let member = null;
-                try { member = await interaction.guild.members.fetch(interaction.user.id); } catch (_) {}
+                try { member = await interaction.guild.members.fetch(interaction.user.id); } catch (err) { console.error('src/events/interactionCreate.js', err); }
                 if (!member) {
-                    try { await interaction.reply({ content: 'Could not fetch your member data.', ephemeral: true }); } catch (_) {}
+                    try { await interaction.reply({ content: 'Could not fetch your member data.', ephemeral: true }); } catch (err) { console.error('src/events/interactionCreate.js', err); }
                     return;
                 }
                 const me = interaction.guild.members.me;
                 if (!me.permissions.has(PermissionsBitField.Flags.ManageRoles) || role.managed || me.roles.highest.comparePositionTo(role) <= 0) {
-                    try { await interaction.reply({ content: 'I cannot assign the verification role due to missing permission or role hierarchy.', ephemeral: true }); } catch (_) {}
+                    try { await interaction.reply({ content: 'I cannot assign the verification role due to missing permission or role hierarchy.', ephemeral: true }); } catch (err) { console.error('src/events/interactionCreate.js', err); }
                     return;
                 }
                 try {
                     await member.roles.add(role, 'User verified via captcha');
-                    try { await interaction.reply({ content: 'Verification passed. Role assigned. Welcome!', ephemeral: true }); } catch (_) {}
+                    try { await interaction.reply({ content: 'Verification passed. Role assigned. Welcome!', ephemeral: true }); } catch (err) { console.error('src/events/interactionCreate.js', err); }
                 } catch (err) {
-                    try { await interaction.reply({ content: `Failed to assign role: ${err.message}`, ephemeral: true }); } catch (_) {}
+                    try { await interaction.reply({ content: `Failed to assign role: ${err.message}`, ephemeral: true }); } catch (err) { console.error('src/events/interactionCreate.js', err); }
                 }
                 return;
             }

--- a/src/events/messageCreate.js
+++ b/src/events/messageCreate.js
@@ -34,14 +34,14 @@ module.exports = {
             default:
               matched = hay.includes(needle);
           }
-        } catch (_) { matched = false; }
+        } catch (err) { console.error('src/events/messageCreate.js', err); matched = false; }
 
         if (matched) {
-          try { await message.reply({ content: String(rule.reply || '').slice(0, 2000) }); } catch (_) {}
+          try { await message.reply({ content: String(rule.reply || '').slice(0, 2000) }); } catch (err) { console.error('src/events/messageCreate.js', err); }
           // do not break; allow multiple rules to respond if applicable
         }
       }
-    } catch (_) { /* swallow */ }
+    } catch (err) { console.error('src/events/messageCreate.js', err); /* swallow */ }
   }
 };
 

--- a/src/events/messageDelete.js
+++ b/src/events/messageDelete.js
@@ -33,7 +33,7 @@ module.exports = {
             return channelOk && targetOk && recent;
           });
           if (entry) executor = entry.executor || null;
-        } catch (_) {
+        } catch (err) { console.error('src/events/messageDelete.js', err);
           // ignore fetch/audit issues
         }
       }
@@ -44,7 +44,7 @@ module.exports = {
         try {
           const m = await guild.members.fetch(executor.id);
           isStaffDeleter = m.permissions.has(PermissionsBitField.Flags.Administrator) || m.permissions.has(PermissionsBitField.Flags.ManageMessages);
-        } catch (_) { /* ignore */ }
+        } catch (err) { console.error('src/events/messageDelete.js', err); /* ignore */ }
       }
       // If executor unknown, still alert owners as requested
       if (executor && !isStaffDeleter) return; // known non-staff deleter, skip

--- a/src/runner.js
+++ b/src/runner.js
@@ -34,7 +34,7 @@ function run(cmd, args, options = {}) {
       await run('git', ['fetch', '--all', '--prune']);
       if (gitBranch) {
         console.log(`[runner] git checkout ${gitBranch}`);
-        try { await run('git', ['checkout', gitBranch]); } catch (_) {}
+        try { await run('git', ['checkout', gitBranch]); } catch (err) { console.error('src/runner.js', err); }
       }
       console.log('[runner] git pull --ff-only');
       await run('git', ['pull', '--ff-only']);

--- a/src/utils/autoPostScheduler.js
+++ b/src/utils/autoPostScheduler.js
@@ -25,11 +25,11 @@ function startJob(client, guildId, job) {
       if (!guild) return;
       let channel = guild.channels.cache.get(job.channelId);
       if (!channel) {
-        try { channel = await guild.channels.fetch(job.channelId); } catch (_) { channel = null; }
+        try { channel = await guild.channels.fetch(job.channelId); } catch (err) { console.error('src/utils/autoPostScheduler.js', err); channel = null; }
       }
       if (!channel) return;
       await channel.send({ content: job.message, allowedMentions: { parse: [] } });
-    } catch (_) {}
+    } catch (err) { console.error('src/utils/autoPostScheduler.js', err); }
   }, interval);
   timers.set(k, handle);
 }

--- a/src/utils/errorConsoleRelay.js
+++ b/src/utils/errorConsoleRelay.js
@@ -5,7 +5,7 @@ function formatArg(a) {
     if (a instanceof Error) return a.stack || `${a.name}: ${a.message}`;
     if (typeof a === 'object') return JSON.stringify(a, null, 2);
     return String(a);
-  } catch (_) {
+  } catch (err) { console.error('src/utils/errorConsoleRelay.js', err);
     try { return String(a); } catch { return '[Unprintable]'; }
   }
 }
@@ -64,13 +64,13 @@ function install(client) {
             await ch.send({ content });
             continue;
           }
-        } catch (_) { /* fall through to owners */ }
+        } catch (err) { console.error('src/utils/errorConsoleRelay.js', err); /* fall through to owners */ }
       }
       for (const id of owners) {
         try {
           const u = await client.users.fetch(id);
           await u.send({ content });
-        } catch (_) { /* ignore DM failures */ }
+        } catch (err) { console.error('src/utils/errorConsoleRelay.js', err); /* ignore DM failures */ }
       }
     }
   }
@@ -109,7 +109,7 @@ function install(client) {
         } else {
           scheduleFlush(level);
         }
-      } catch (_) {
+      } catch (err) { console.error('src/utils/errorConsoleRelay.js', err);
         try { originals.error('[errorConsoleRelay] failed to relay console.' + level); } catch {}
       }
     };

--- a/src/utils/guildColourStore.js
+++ b/src/utils/guildColourStore.js
@@ -13,7 +13,7 @@ function ensureStore() {
     if (!fs.existsSync(STORE_FILE)) {
       fs.writeFileSync(STORE_FILE, JSON.stringify({ guilds: {} }, null, 2), 'utf8');
     }
-  } catch (_) {
+  } catch (err) { console.error('src/utils/guildColourStore.js', err);
     // best-effort; read/write calls will handle errors
   }
 }

--- a/src/utils/jailStore.js
+++ b/src/utils/jailStore.js
@@ -5,9 +5,9 @@ const DATA_DIR = path.join(__dirname, '..', '..', 'data');
 const FILE = path.join(DATA_DIR, 'jail.json');
 
 function ensureFile() {
-  try { if (!fs.existsSync(DATA_DIR)) fs.mkdirSync(DATA_DIR, { recursive: true }); } catch (_) {}
+  try { if (!fs.existsSync(DATA_DIR)) fs.mkdirSync(DATA_DIR, { recursive: true }); } catch (err) { console.error('src/utils/jailStore.js', err); }
   if (!fs.existsSync(FILE)) {
-    try { fs.writeFileSync(FILE, JSON.stringify({ guilds: {} }, null, 2)); } catch (_) {}
+    try { fs.writeFileSync(FILE, JSON.stringify({ guilds: {} }, null, 2)); } catch (err) { console.error('src/utils/jailStore.js', err); }
   }
 }
 
@@ -18,14 +18,14 @@ function load() {
     const parsed = JSON.parse(raw || '{}');
     if (!parsed.guilds || typeof parsed.guilds !== 'object') parsed.guilds = {};
     return parsed;
-  } catch (_) {
+  } catch (err) { console.error('src/utils/jailStore.js', err);
     return { guilds: {} };
   }
 }
 
 function save(data) {
   ensureFile();
-  try { fs.writeFileSync(FILE, JSON.stringify(data, null, 2)); } catch (_) {}
+  try { fs.writeFileSync(FILE, JSON.stringify(data, null, 2)); } catch (err) { console.error('src/utils/jailStore.js', err); }
 }
 
 function getGuild(data, guildId) {

--- a/src/utils/welcomeStore.js
+++ b/src/utils/welcomeStore.js
@@ -10,7 +10,7 @@ function ensure() {
   try {
     if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true });
     if (!fs.existsSync(file)) fs.writeFileSync(file, JSON.stringify({}, null, 2), 'utf8');
-  } catch (_) {}
+  } catch (err) { console.error('src/utils/welcomeStore.js', err); }
 }
 
 function load() {


### PR DESCRIPTION
## Summary
- replace silent `catch` blocks with error logging across commands, events, and utils so issues surface with file context
- ensure user-facing commands capture and log unexpected failures rather than ignoring them

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba6ee1fc60833187eb1c445804941c