### PR TITLE
feat: add log configuration summary command

### DIFF
--- a/src/commands/logconfig.js
+++ b/src/commands/logconfig.js
@@ -7,7 +7,7 @@ const joinLogConfigStore = require('../utils/joinLogConfigStore');
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('logconfig')
-    .setDescription('Show a summary of logging-related configurations'),
+    .setDescription('Show the status of logging configuration'),
 
   async execute(interaction) {
     if (!interaction.inGuild()) {
@@ -22,39 +22,36 @@ module.exports = {
 
     const guildId = interaction.guildId;
 
-    // Fetch states in parallel
-    const [securityEnabled, modEnabled, monitoredList] = await Promise.all([
+    const [securityEnabled, modEnabled, channelList] = await Promise.all([
       securityLogStore.getEnabled(guildId),
       modLogStore.getEnabled(guildId),
       logChannelsStore.list(guildId),
     ]);
-    const joinCfg = joinLogConfigStore.getConfig(guildId); // sync store
-
-    const monitoredEnabled = Array.isArray(monitoredList) && monitoredList.length > 0;
-    const joinLogLinked = !!joinCfg;
-
-    const check = (b) => (b ? '✅ Enabled' : '❌ Disabled');
+    const joinCfg = joinLogConfigStore.getConfig(guildId); // synchronous
 
     const embed = new EmbedBuilder()
       .setTitle('Logging Configuration')
       .addFields(
-        { name: 'Security Log', value: check(!!securityEnabled), inline: true },
-        { name: 'Moderation Log', value: check(!!modEnabled), inline: true },
-        { name: 'Monitored Channels', value: monitoredEnabled ? `✅ Enabled (${monitoredList.length})` : '❌ Disabled', inline: true },
-        { name: 'Join Log Link', value: joinLogLinked ? '✅ Linked' : '❌ Not linked', inline: true },
+        { name: 'Security Log', value: securityEnabled ? '✅' : '❌', inline: true },
+        { name: 'Moderation Log', value: modEnabled ? '✅' : '❌', inline: true },
+        {
+          name: 'Log Channels',
+          value: Array.isArray(channelList) && channelList.length > 0 ? '✅' : '❌',
+          inline: true,
+        },
+        { name: 'Join Log Config', value: joinCfg ? '✅' : '❌', inline: true },
       );
 
-    // Apply default guild colour if available
     try {
       const { applyDefaultColour } = require('../utils/guildColourStore');
       applyDefaultColour(embed, guildId);
     } catch (_) {
-      // Colour application failed, continue without it
+      // ignore colour failures
     }
 
     try {
       await interaction.editReply({ embeds: [embed] });
-    } catch (err) {
+    } catch {
       await interaction.editReply({ content: 'Failed to build log configuration summary.' });
     }
   },


### PR DESCRIPTION
## Summary
- add `/logconfig` command that summarizes logging-related settings for a guild

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baba0144d88331981887a18fa4bb79