### PR TITLE
Add logconfig help entry

### DIFF
--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -45,6 +45,7 @@ const categories = {
     ['/- securitylog toggle', 'Enable or disable security logging as a whole.'],
     ['/- modlog set/mode/toggle/show', 'Configure moderation action logging (bans, kicks, mutes, role changes).'],
     ['/- logchannels', 'Show configured log channels.'],
+    ['/- logconfig', 'Show status of all logging categories.'],
     ['/- securityreport', 'Who triggered permission/hierarchy/missing-command events.'],
     ['/- channelsync', 'Sync channels to their category permissions. Requires Manage Channels.'],
   ],


### PR DESCRIPTION
## Summary
- document `/logconfig` in help list under Security

## Testing
- `npm test`
- `node src/commands/help.js` (via `node - <<'NODE'` script) to confirm `/logconfig` appears in Security help


------
https://chatgpt.com/codex/tasks/task_e_68baba009b888331b71ea35f7d69166c