### PR TITLE
Replace emoji log states with text

### DIFF
--- a/src/commands/logconfig.js
+++ b/src/commands/logconfig.js
@@ -32,14 +32,14 @@ module.exports = {
     const embed = new EmbedBuilder()
       .setTitle('Logging Configuration')
       .addFields(
-        { name: 'Security Log', value: securityEnabled ? '✅' : '❌', inline: true },
-        { name: 'Moderation Log', value: modEnabled ? '✅' : '❌', inline: true },
+        { name: 'Security Log', value: securityEnabled ? 'On' : 'Off', inline: true },
+        { name: 'Moderation Log', value: modEnabled ? 'On' : 'Off', inline: true },
         {
           name: 'Log Channels',
-          value: Array.isArray(channelList) && channelList.length > 0 ? '✅' : '❌',
+          value: Array.isArray(channelList) && channelList.length > 0 ? `On (${channelList.length})` : 'Off',
           inline: true,
         },
-        { name: 'Join Log Config', value: joinCfg ? '✅' : '❌', inline: true },
+        { name: 'Join Log Config', value: joinCfg ? 'Linked' : 'Not linked', inline: true },
       );
 
     try {

--- a/tests/logconfig.test.js
+++ b/tests/logconfig.test.js
@@ -38,10 +38,10 @@ test('logconfig shows correct states for enabled and disabled', async () => {
     const interaction1 = createInteraction();
     await logconfig.execute(interaction1);
     const fields1 = interaction1.getReply().embeds[0].data.fields;
-    assert.strictEqual(fields1[0].value, '✅ Enabled');
-    assert.strictEqual(fields1[1].value, '✅ Enabled');
-    assert.strictEqual(fields1[2].value, '✅ Enabled (2)');
-    assert.strictEqual(fields1[3].value, '✅ Linked');
+    assert.strictEqual(fields1[0].value, 'On');
+    assert.strictEqual(fields1[1].value, 'On');
+    assert.strictEqual(fields1[2].value, 'On (2)');
+    assert.strictEqual(fields1[3].value, 'Linked');
 
     // Disabled scenario
     securityLogStore.getEnabled = async () => false;
@@ -52,10 +52,10 @@ test('logconfig shows correct states for enabled and disabled', async () => {
     const interaction2 = createInteraction();
     await logconfig.execute(interaction2);
     const fields2 = interaction2.getReply().embeds[0].data.fields;
-    assert.strictEqual(fields2[0].value, '❌ Disabled');
-    assert.strictEqual(fields2[1].value, '❌ Disabled');
-    assert.strictEqual(fields2[2].value, '❌ Disabled');
-    assert.strictEqual(fields2[3].value, '❌ Not linked');
+    assert.strictEqual(fields2[0].value, 'Off');
+    assert.strictEqual(fields2[1].value, 'Off');
+    assert.strictEqual(fields2[2].value, 'Off');
+    assert.strictEqual(fields2[3].value, 'Not linked');
   } finally {
     securityLogStore.getEnabled = origSec;
     modLogStore.getEnabled = origMod;


### PR DESCRIPTION
## Summary
- Remove emoji indicators from logging configuration output
- Update tests to expect text `On/Off` states instead of emoji

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb251e4cb0833183a7f42fde402c36