### PR TITLE
Add webhooks slash command

### DIFF
--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -56,6 +56,7 @@ const categories = {
   ],
   'System': [
     ['/- botinfo', 'Show instance, mode, commands loaded, uptime.'],
+    ['/- webhooks', 'List server webhooks and their creators. Requires Manage Webhooks.'],
   ],
   'Owner Only': [
     ['/- adminlist', '\u200B'],

--- a/src/commands/webhooks.js
+++ b/src/commands/webhooks.js
@@ -1,0 +1,29 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('webhooks')
+    .setDescription('List all webhooks in this server and their creators'),
+
+  async execute(interaction) {
+    try {
+      const webhooks = await interaction.guild.fetchWebhooks();
+      if (!webhooks.size) {
+        await interaction.reply('No webhooks found.');
+        return;
+      }
+      const lines = webhooks.map((wh) => {
+        const creator = wh.owner?.tag || 'Unknown';
+        return `• ${wh.name} (ID: ${wh.id}) - created by ${creator}`;
+      });
+      const content = lines.join('\n');
+      if (content.length <= 2000) {
+        await interaction.reply(content);
+      } else {
+        await interaction.reply({ content: 'Too many webhooks to display.', ephemeral: true });
+      }
+    } catch (error) {
+      await interaction.reply({ content: 'Failed to fetch webhooks.', ephemeral: true });
+    }
+  },
+};


### PR DESCRIPTION
## Summary
- add `/webhooks` command to list server webhooks and their creators
- include new command in help menu

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb7fa65ce88331b97c54219b8737fb