### PR TITLE
docs: clarify development command deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
    ```env
    DISCORD_TOKEN=your_bot_token_here
    CLIENT_ID=your_client_id_here
-   GUILD_ID=your_guild_id_for_testing
+   # Comma-separated guild IDs for instant dev testing (optional)
+   GUILD_IDS=your_guild_id_for_testing
    NODE_ENV=production
    ```
 
@@ -20,6 +21,8 @@
    ```bash
    node deploy-commands.js
    ```
+   > **Note:** Global command deployments can take up to an hour to reach all servers.
+   > To test immediately in specific guilds, set `NODE_ENV=development` and provide `GUILD_IDS` before running the deploy script.
 
 5. Start the bot:
    ```bash
@@ -27,9 +30,10 @@
    ```
 
 ### 4. Development Mode
-For faster command testing in a specific server:
+Global commands are cached by Discord and may not appear for up to an hour.
+For immediate command availability in specific guilds:
 1. Set `NODE_ENV=development` in your `.env`
-2. Add your test server's `GUILD_ID`
+2. Add your test server IDs to `GUILD_IDS` (comma-separated)
 3. Run `node deploy-commands.js`
 
 

--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -53,6 +53,7 @@ const rest = new REST().setToken(process.env.DISCORD_TOKEN);
             throw new Error('Missing CLIENT_ID in environment.');
         }
 
+        // Guild-scoped commands appear instantly, whereas global updates may take up to an hour to propagate.
         if (env === 'development' && guildIds.length > 0) {
             // Deploy to one or more guilds for faster iteration
             console.log(`Target scope: guild (${guildIds.join(', ')})`);
@@ -68,7 +69,7 @@ const rest = new REST().setToken(process.env.DISCORD_TOKEN);
                 console.log('DRY-RUN: Skipping REST deployment for guild scope.');
             }
         } else {
-            // Deploy globally
+            // Deploy globally (slower propagation across Discord)
             console.log('Target scope: global');
             if (!isDryRun) {
                 const data = await rest.put(


### PR DESCRIPTION
## Summary
- Highlight global deploy delay and recommend `NODE_ENV=development` with `GUILD_IDS` for instant guild testing
- Explain latency difference between guild and global command deployments in `deploy-commands.js`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb91920cd083318c1138aa737f8b1f