### PR TITLE
feat: support single bot owner ID

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+DISCORD_TOKEN=your_bot_token_here
+CLIENT_ID=your_client_id_here
+GUILD_ID=your_guild_id_for_testing
+NODE_ENV=production
+
+# Space or comma separated list of bot owner user IDs.
+# BOT_OWNER_IDS takes precedence over BOT_OWNER_ID when both are set.
+BOT_OWNER_IDS=
+# Single bot owner user ID used if BOT_OWNER_IDS is unset.
+BOT_OWNER_ID=
+
+# Optional: when set to true, fall back to DMing owners if log channel fails.
+# OWNER_FALLBACK_ON_CHANNEL_FAIL=true

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
    CLIENT_ID=your_client_id_here
    GUILD_ID=your_guild_id_for_testing
    NODE_ENV=production
+   # BOT_OWNER_IDS=123456789012345678 234567890123456789
+   # BOT_OWNER_ID=123456789012345678
    ```
 
 4. Deploy slash commands:
@@ -60,3 +62,5 @@ This project is licensed under the MIT License.
 ### Environment Variables
 
 - `OWNER_FALLBACK_ON_CHANNEL_FAIL`: When set to `true`, if a guild’s log delivery mode is set to `channel` and sending to the configured channel fails (missing/not set/inaccessible), the bot will fall back to DMing bot owners. When unset or `false`, no owner-DM fallback occurs in `channel` mode. Applies to both moderation and security logs.
+- `BOT_OWNER_IDS`: Space or comma separated list of bot owner user IDs. Takes precedence over `BOT_OWNER_ID` when both are set.
+- `BOT_OWNER_ID`: Single bot owner user ID used if `BOT_OWNER_IDS` is unset.

--- a/src/commands/adminlist.js
+++ b/src/commands/adminlist.js
@@ -1,10 +1,5 @@
 const { SlashCommandBuilder, PermissionsBitField, EmbedBuilder } = require('discord.js');
-
-function isOwner(userId) {
-  const raw = process.env.BOT_OWNER_IDS || '';
-  const ids = raw.split(/[\s,]+/).map(s => s.trim()).filter(Boolean);
-  return ids.includes(String(userId));
-}
+const { isOwner } = require('../utils/ownerIds');
 
 function sleep(ms) { return new Promise(res => setTimeout(res, ms)); }
 

--- a/src/commands/dmdiag.js
+++ b/src/commands/dmdiag.js
@@ -1,11 +1,6 @@
 const { SlashCommandBuilder, PermissionsBitField, EmbedBuilder } = require('discord.js');
 const logger = require('../utils/securityLogger');
-
-function isOwner(userId) {
-  const raw = process.env.BOT_OWNER_IDS || '';
-  const ids = raw.split(/[\s,]+/).map(s => s.trim()).filter(Boolean);
-  return ids.includes(String(userId));
-}
+const { isOwner } = require('../utils/ownerIds');
 
 function sleep(ms) { return new Promise(res => setTimeout(res, ms)); }
 

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,10 +1,5 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
-
-function isOwner(userId) {
-  const raw = process.env.BOT_OWNER_IDS || '';
-  const ids = raw.split(/[\s,]+/).map(s => s.trim()).filter(Boolean);
-  return ids.includes(String(userId));
-}
+const { isOwner } = require('../utils/ownerIds');
 
 const categories = {
   'Moderation': [

--- a/src/commands/isolate.js
+++ b/src/commands/isolate.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, ChannelType, PermissionsBitField } = require('discord.js');
 const logger = require('../utils/securityLogger');
+const { isOwner } = require('../utils/ownerIds');
 
 // In-memory store for active isolations per guild+user
 // Key: `${guildId}:${userId}` -> { channelId, intervalId, stopAt }
@@ -44,11 +45,8 @@ module.exports = {
       return interaction.reply({ content: 'Use this command in a server.', ephemeral: true });
     }
 
-    // Bot owner-only check via BOT_OWNER_IDS
-    const raw = process.env.BOT_OWNER_IDS || '';
-    const owners = raw.split(/[\s,]+/).map(s => s.trim()).filter(Boolean);
-    const isOwner = owners.includes(String(interaction.user.id));
-    if (!isOwner) {
+    // Bot owner-only check
+    if (!isOwner(interaction.user.id)) {
       try { await logger.logPermissionDenied(interaction, 'wraith', 'User is not a bot owner'); } catch (_) {}
       return interaction.reply({ content: 'This command is restricted to bot owners.', ephemeral: true });
     }

--- a/src/utils/ownerIds.js
+++ b/src/utils/ownerIds.js
@@ -1,6 +1,13 @@
 function parseOwnerIds() {
   const raw = process.env.BOT_OWNER_IDS || '';
-  return raw.split(/[\s,]+/).map(s => s.trim()).filter(Boolean);
+  const ids = raw.split(/[\s,]+/).map(s => s.trim()).filter(Boolean);
+  if (ids.length) return ids;
+  const single = process.env.BOT_OWNER_ID;
+  return single ? [String(single).trim()] : [];
 }
 
-module.exports = { parseOwnerIds };
+function isOwner(userId) {
+  return parseOwnerIds().includes(String(userId));
+}
+
+module.exports = { parseOwnerIds, isOwner };


### PR DESCRIPTION
## Summary
- allow configuring a single bot owner via `BOT_OWNER_ID`
- centralize owner checks through `isOwner` helper
- document owner ID variables in README and `.env.example`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb9182dcf08331aaa8f7d0f39fe88b