### PR TITLE
Gracefully handle command load failures

### DIFF
--- a/src/handlers/commandHandler.js
+++ b/src/handlers/commandHandler.js
@@ -24,7 +24,13 @@ function loadCommands(client) {
     const commandFiles = getAllFiles(commandsPath);
 
     for (const filePath of commandFiles) {
-        const command = require(filePath);
+        let command;
+        try {
+            command = require(filePath);
+        } catch (err) {
+            console.log(`⚠ Failed to load command at ${filePath}: ${err.message}`);
+            continue;
+        }
 
         if ('data' in command && 'execute' in command) {
             client.commands.set(command.data.name, command);

--- a/tests/commandHandler.test.js
+++ b/tests/commandHandler.test.js
@@ -1,0 +1,23 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { loadCommands } = require('../src/handlers/commandHandler');
+
+test('malformed command is logged and skipped', () => {
+  const commandsDir = path.join(__dirname, '..', 'src', 'commands');
+  const badFile = path.join(commandsDir, 'malformed.test.js');
+  fs.writeFileSync(badFile, 'module.exports = { data: { name: "bad" }, execute() { }');
+  const originalLog = console.log;
+  const logs = [];
+  console.log = (...args) => logs.push(args.join(' '));
+  try {
+    const client = { commands: new Map() };
+    assert.doesNotThrow(() => loadCommands(client));
+    assert(!client.commands.has('bad'));
+    assert(logs.some(l => l.includes('Failed to load command') && l.includes('malformed.test.js')));
+  } finally {
+    console.log = originalLog;
+    fs.unlinkSync(badFile);
+  }
+});


### PR DESCRIPTION
## Summary
- handle command require errors in `loadCommands` without exiting
- add test ensuring malformed command files are skipped

## Testing
- ⚠️ `npm test` *(failed: command not found)*
- ⚠️ `apt-get update` *(failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bb918c06f483319a6013cffdb892c9