### PR TITLE
Avoid deploying duplicate slash commands

### DIFF
--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -17,21 +17,23 @@ function getAllCommandFiles(dir) {
 const commandsDir = path.join(__dirname, 'src', 'commands');
 const commands = [];
 const files = getAllCommandFiles(commandsDir);
-const names = new Set();
+const nameToFile = new Map();
 for (const filePath of files) {
     const command = require(filePath);
     if ('data' in command && 'execute' in command) {
         const json = command.data.toJSON();
-        if (names.has(json.name)) {
-            console.log(`[WARNING] Duplicate slash command name '${json.name}' in ${filePath}; previous definition will be overwritten in Discord UI.`);
+        if (nameToFile.has(json.name)) {
+            const firstPath = nameToFile.get(json.name);
+            console.log(`[WARNING] Duplicate slash command name '${json.name}' in ${filePath}; skipping (already defined in ${firstPath}).`);
+            continue;
         }
-        names.add(json.name);
+        nameToFile.set(json.name, filePath);
         commands.push(json);
     } else {
         console.log(`[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`);
     }
 }
-console.log('Commands to deploy:', Array.from(names).join(', ') || '(none)');
+console.log('Commands to deploy:', Array.from(nameToFile.keys()).join(', ') || '(none)');
 
 const args = process.argv.slice(2);
 const isDryRun = args.includes('--dry-run') || process.env.DRY_RUN === '1';

--- a/tests/deploy-commands.test.js
+++ b/tests/deploy-commands.test.js
@@ -1,0 +1,52 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const rootDir = path.join(__dirname, '..');
+const commandsDir = path.join(rootDir, 'src', 'commands');
+
+function runDeploy() {
+  return spawnSync('node', ['deploy-commands.js', '--dry-run'], {
+    cwd: rootDir,
+    env: {
+      ...process.env,
+      DRY_RUN: '1',
+      CLIENT_ID: 'test-client',
+      DISCORD_TOKEN: 'test-token',
+      NODE_ENV: 'development',
+      GUILD_ID: '123'
+    },
+    encoding: 'utf8'
+  });
+}
+
+test('duplicate commands are ignored', async () => {
+  const baseline = runDeploy();
+  assert.strictEqual(baseline.status, 0);
+  const baseMatch = baseline.stdout.match(/Preparing to refresh (\d+) application/);
+  assert.ok(baseMatch, 'could not parse baseline command count');
+  const baseCount = Number(baseMatch[1]);
+
+  const file1 = path.join(commandsDir, 'a-duptest.js');
+  const file2 = path.join(commandsDir, 'b-duptest.js');
+  const content = `const { SlashCommandBuilder } = require('discord.js');
+module.exports = { data: new SlashCommandBuilder().setName('duptest').setDescription('test'), async execute() {} };`;
+  fs.writeFileSync(file1, content);
+  fs.writeFileSync(file2, content);
+
+  try {
+    const run = runDeploy();
+    assert.strictEqual(run.status, 0);
+    assert.ok(run.stdout.includes("Duplicate slash command name 'duptest'"), 'missing duplicate warning');
+    assert.ok(run.stdout.includes('b-duptest.js'), 'missing file path for skipped command');
+    const match = run.stdout.match(/Preparing to refresh (\d+) application/);
+    assert.ok(match, 'could not parse command count');
+    const count = Number(match[1]);
+    assert.strictEqual(count, baseCount + 1);
+  } finally {
+    fs.unlinkSync(file1);
+    fs.unlinkSync(file2);
+  }
+});


### PR DESCRIPTION
## Summary
- Skip later duplicate slash command definitions when collecting commands
- Log the skipped file path to aid debugging
- Add regression test ensuring duplicates are ignored

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb91a8b4ac8331815ae75727934bf5