### PR TITLE
Handle event load failures

### DIFF
--- a/src/handlers/eventHandler.js
+++ b/src/handlers/eventHandler.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 function loadEvents(client) {
     const eventsPath = path.join(__dirname, '..', 'events');
-    
+
     if (!fs.existsSync(eventsPath)) {
         console.log('Events directory not found, creating...');
         fs.mkdirSync(eventsPath, { recursive: true });
@@ -14,16 +14,24 @@ function loadEvents(client) {
 
     for (const file of eventFiles) {
         const filePath = path.join(eventsPath, file);
-        const event = require(filePath);
+        let event;
+
+        try {
+            event = require(filePath);
+        } catch (error) {
+            console.error(`Failed to load event ${file}:`, error);
+            continue;
+        }
 
         if (event.once) {
             client.once(event.name, (...args) => event.execute(...args));
         } else {
             client.on(event.name, (...args) => event.execute(...args));
         }
-        
+
         console.log(`✓ Loaded event: ${event.name}`);
     }
 }
 
 module.exports = { loadEvents };
+


### PR DESCRIPTION
## Summary
- catch and log failures when loading event modules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb95da669483319eff405ed46aeac0