### PR TITLE
Clarify GUILD_IDS usage for test guild configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 DISCORD_TOKEN=your_bot_token_here
 CLIENT_ID=your_client_id_here
-GUILD_ID=your_guild_id_for_testing
+# Comma-separated guild IDs for instant dev testing (optional)
+GUILD_IDS=your_guild_id_for_testing
+# Alternatively, use GUILD_ID for a single test guild
 NODE_ENV=production
 
 # Space or comma separated list of bot owner user IDs.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
    CLIENT_ID=your_client_id_here
    # Comma-separated guild IDs for instant dev testing (optional)
    GUILD_IDS=your_guild_id_for_testing
+   # Or set GUILD_ID=your_guild_id_for_testing for a single guild
    NODE_ENV=production
    # BOT_OWNER_IDS=123456789012345678 234567890123456789
    # BOT_OWNER_ID=123456789012345678
@@ -24,7 +25,7 @@
    node deploy-commands.js
    ```
    > **Note:** Global command deployments can take up to an hour to reach all servers.
-   > To test immediately in specific guilds, set `NODE_ENV=development` and provide `GUILD_IDS` before running the deploy script.
+   > To test immediately in specific guilds, set `NODE_ENV=development` and provide `GUILD_IDS` (or `GUILD_ID` for a single guild) before running the deploy script.
 
 5. Start the bot:
    ```bash
@@ -35,7 +36,7 @@
 Global commands are cached by Discord and may not appear for up to an hour.
 For immediate command availability in specific guilds:
 1. Set `NODE_ENV=development` in your `.env`
-2. Add your test server IDs to `GUILD_IDS` (comma-separated)
+2. Add your test server IDs to `GUILD_IDS` (comma-separated), or use `GUILD_ID` for a single server
 3. Run `node deploy-commands.js`
 
 
@@ -65,6 +66,8 @@ This project is licensed under the MIT License.
 
 ### Environment Variables
 
+- `GUILD_IDS`: Comma-separated list of guild IDs for instant dev testing.
+- `GUILD_ID`: Single guild ID for testing if only one guild is needed.
 - `OWNER_FALLBACK_ON_CHANNEL_FAIL`: When set to `true`, if a guild’s log delivery mode is set to `channel` and sending to the configured channel fails (missing/not set/inaccessible), the bot will fall back to DMing bot owners. When unset or `false`, no owner-DM fallback occurs in `channel` mode. Applies to both moderation and security logs.
 - `BOT_OWNER_IDS`: Space or comma separated list of bot owner user IDs. Takes precedence over `BOT_OWNER_ID` when both are set.
 - `BOT_OWNER_ID`: Single bot owner user ID used if `BOT_OWNER_IDS` is unset.


### PR DESCRIPTION
## Summary
- switch `.env.example` to use `GUILD_IDS` and note optional `GUILD_ID`
- update README to document both `GUILD_IDS` and `GUILD_ID`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb95dc3e9483318b560fb6bd1a111b