### PR TITLE
Isolate command tests from production commands

### DIFF
--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -14,7 +14,7 @@ function getAllCommandFiles(dir) {
     return files;
 }
 
-const commandsDir = path.join(__dirname, 'src', 'commands');
+const commandsDir = process.env.COMMANDS_DIR || path.join(__dirname, 'src', 'commands');
 const commands = [];
 const files = getAllCommandFiles(commandsDir);
 const nameToFile = new Map();

--- a/src/handlers/commandHandler.js
+++ b/src/handlers/commandHandler.js
@@ -1,9 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 
-function loadCommands(client) {
-    const commandsPath = path.join(__dirname, '..', 'commands');
-    
+function loadCommands(client, commandsPath = path.join(__dirname, '..', 'commands')) {
     if (!fs.existsSync(commandsPath)) {
         console.log('Commands directory not found, creating...');
         fs.mkdirSync(commandsPath, { recursive: true });

--- a/tests/commandHandler.test.js
+++ b/tests/commandHandler.test.js
@@ -2,22 +2,23 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 const { loadCommands } = require('../src/handlers/commandHandler');
 
 test('malformed command is logged and skipped', () => {
-  const commandsDir = path.join(__dirname, '..', 'src', 'commands');
-  const badFile = path.join(commandsDir, 'malformed.test.js');
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cmds-'));
+  const badFile = path.join(tmpDir, 'malformed.test.js');
   fs.writeFileSync(badFile, 'module.exports = { data: { name: "bad" }, execute() { }');
   const originalLog = console.log;
   const logs = [];
   console.log = (...args) => logs.push(args.join(' '));
   try {
     const client = { commands: new Map() };
-    assert.doesNotThrow(() => loadCommands(client));
+    assert.doesNotThrow(() => loadCommands(client, tmpDir));
     assert(!client.commands.has('bad'));
     assert(logs.some(l => l.includes('Failed to load command') && l.includes('malformed.test.js')));
   } finally {
     console.log = originalLog;
-    fs.unlinkSync(badFile);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });

--- a/tests/deploy-commands.test.js
+++ b/tests/deploy-commands.test.js
@@ -2,28 +2,27 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 const { spawnSync } = require('child_process');
 
-const rootDir = path.join(__dirname, '..');
-const commandsDir = path.join(rootDir, 'src', 'commands');
-
-function runDeploy() {
-  return spawnSync('node', ['deploy-commands.js', '--dry-run'], {
-    cwd: rootDir,
+function runDeploy(dir) {
+  return spawnSync('node', [path.join(__dirname, '..', 'deploy-commands.js'), '--dry-run'], {
     env: {
       ...process.env,
       DRY_RUN: '1',
       CLIENT_ID: 'test-client',
       DISCORD_TOKEN: 'test-token',
       NODE_ENV: 'development',
-      GUILD_ID: '123'
+      GUILD_ID: '123',
+      COMMANDS_DIR: dir
     },
     encoding: 'utf8'
   });
 }
 
 test('duplicate commands are ignored', async () => {
-  const baseline = runDeploy();
+  const commandsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'deploy-cmds-'));
+  const baseline = runDeploy(commandsDir);
   assert.strictEqual(baseline.status, 0);
   const baseMatch = baseline.stdout.match(/Preparing to refresh (\d+) application/);
   assert.ok(baseMatch, 'could not parse baseline command count');
@@ -31,13 +30,12 @@ test('duplicate commands are ignored', async () => {
 
   const file1 = path.join(commandsDir, 'a-duptest.js');
   const file2 = path.join(commandsDir, 'b-duptest.js');
-  const content = `const { SlashCommandBuilder } = require('discord.js');
-module.exports = { data: new SlashCommandBuilder().setName('duptest').setDescription('test'), async execute() {} };`;
+  const content = `module.exports = { data: { toJSON() { return { name: 'duptest' }; } }, async execute() {} };`;
   fs.writeFileSync(file1, content);
   fs.writeFileSync(file2, content);
 
   try {
-    const run = runDeploy();
+    const run = runDeploy(commandsDir);
     assert.strictEqual(run.status, 0);
     assert.ok(run.stdout.includes("Duplicate slash command name 'duptest'"), 'missing duplicate warning');
     assert.ok(run.stdout.includes('b-duptest.js'), 'missing file path for skipped command');
@@ -46,7 +44,6 @@ module.exports = { data: new SlashCommandBuilder().setName('duptest').setDescrip
     const count = Number(match[1]);
     assert.strictEqual(count, baseCount + 1);
   } finally {
-    fs.unlinkSync(file1);
-    fs.unlinkSync(file2);
+    fs.rmSync(commandsDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary
- allow `loadCommands` and `deploy-commands.js` to load commands from a custom directory
- refactor tests to create temporary command directories

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb95dcf4b483319d8d50f72b0f25a5