### PR TITLE
feat: add interactive help menu

### DIFF
--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,69 +1,78 @@
-const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const {
+  SlashCommandBuilder,
+  EmbedBuilder,
+  ActionRowBuilder,
+  StringSelectMenuBuilder,
+  ComponentType,
+} = require('discord.js');
 const { isOwner } = require('../utils/ownerIds');
 
 const categories = {
-  'Moderation': [
-    ['/- mute', 'Timeout a member (10m, 1h, 2d). Requires Moderate Members.'],
-    ['/- kick', 'Kick a member. Requires Kick Members.'],
-    ['/- ban', 'Ban a user; optional prune_days (0–7). Requires Ban Members.'],
-    ['/- blacklist add/remove/list', 'Blacklist users to auto-ban on join. Requires Ban Members.'],
-    ['/- purge', 'Delete 1–100 recent messages here. Requires Manage Messages.'],
-    ['/- jail config/add/remove/status', 'Jail system to restrict and restore members. Requires Manage Roles.'],
+  Moderation: [
+    { cmd: '/mute', desc: 'Timeout a member (10m, 1h, 2d)', perm: 'Moderate Members' },
+    { cmd: '/kick', desc: 'Kick a member', perm: 'Kick Members' },
+    { cmd: '/ban', desc: 'Ban a user; optional prune_days (0–7)', perm: 'Ban Members' },
+    { cmd: '/blacklist add/remove/list', desc: 'Blacklist users to auto-ban on join', perm: 'Ban Members' },
+    { cmd: '/purge', desc: 'Delete 1–100 recent messages here', perm: 'Manage Messages' },
+    { cmd: '/jail config/add/remove/status', desc: 'Jail system to restrict and restore members', perm: 'Manage Roles' },
   ],
-  'Roles': [
-    ['/- autoroles add/remove/list/clear', 'Auto-assign roles on join. Requires Manage Roles.'],
-    ['/- role add/remove', 'Add or remove a specific role. Requires Manage Roles.'],
-    ['/- createrole', 'Quickly create a role. Requires Manage Roles.'],
-    ['/- deleterole', 'Delete a role. Requires Manage Roles.'],
-    ['/- reactionrole create', 'Create an embed with a selectable role menu. Requires Manage Roles.'],
+  Roles: [
+    { cmd: '/autoroles add/remove/list/clear', desc: 'Auto-assign roles on join', perm: 'Manage Roles' },
+    { cmd: '/role add/remove', desc: 'Add or remove a specific role', perm: 'Manage Roles' },
+    { cmd: '/createrole', desc: 'Quickly create a role', perm: 'Manage Roles' },
+    { cmd: '/deleterole', desc: 'Delete a role', perm: 'Manage Roles' },
+    { cmd: '/reactionrole create', desc: 'Create an embed with a selectable role menu', perm: 'Manage Roles' },
   ],
   'Emoji & Stickers': [
-    ['/- clone emoji', 'Clone a custom emoji by mention/ID/URL.'],
-    ['/- clone sticker', 'Clone a sticker by ID/URL or upload.'],
-    ['/- cloneall', 'Clone emojis from another server by ID.'],
-    ['/- enlarge emoji', 'Post a large emoji (supports Unicode).'],
-    ['/- enlarge sticker', 'Post a sticker file as an image.'],
+    { cmd: '/clone emoji', desc: 'Clone a custom emoji by mention/ID/URL', perm: null },
+    { cmd: '/clone sticker', desc: 'Clone a sticker by ID/URL or upload', perm: null },
+    { cmd: '/cloneall', desc: 'Clone emojis from another server by ID', perm: null },
+    { cmd: '/enlarge emoji', desc: 'Post a large emoji (supports Unicode)', perm: null },
+    { cmd: '/enlarge sticker', desc: 'Post a sticker file as an image', perm: null },
   ],
-  'Embeds': [
-    ['/- embed create', 'Open modal to build an embed.'],
-    ['/- embed quick', 'Quick embed (description, title, color, etc.).'],
-    ['/- getembed', 'Extract embed JSON from a message.'],
+  Embeds: [
+    { cmd: '/embed create', desc: 'Open modal to build an embed', perm: null },
+    { cmd: '/embed quick', desc: 'Quick embed (description, title, color, etc.)', perm: null },
+    { cmd: '/getembed', desc: 'Extract embed JSON from a message', perm: null },
   ],
   'Member Stats': [
-    ['/- joins leaderboard', 'Top joiners/leavers (optionally by window).'],
-    ['/- joins user', 'Stats for a specific member.'],
-    ['/- joins setlog', 'Link your existing join/leave log channel + keywords.'],
-    ['/- joins backfill', 'Import historical join/leave events from linked channel.'],
+    { cmd: '/joins leaderboard', desc: 'Top joiners/leavers (optionally by window)', perm: null },
+    { cmd: '/joins user', desc: 'Stats for a specific member', perm: null },
+    { cmd: '/joins setlog', desc: 'Link your existing join/leave log channel + keywords', perm: null },
+    { cmd: '/joins backfill', desc: 'Import historical join/leave events from linked channel', perm: null },
   ],
-  'Security': [
-    ['/- securitylog set/clear/show', 'Configure security log channel and view settings.'],
-    ['/- securitylog mode', 'Choose delivery: channel, owners, or both.'],
-    ['/- securitylog toggle', 'Enable or disable security logging as a whole.'],
-    ['/- modlog set/mode/toggle/show', 'Configure moderation action logging (bans, kicks, mutes, role changes).'],
-    ['/- logchannels', 'Show configured log channels.'],
-    ['/- logconfig', 'Show status of all logging categories.'],
-    ['/- securityreport', 'Who triggered permission/hierarchy/missing-command events.'],
-    ['/- channelsync', 'Sync channels to their category permissions. Requires Manage Channels.'],
+  Security: [
+    { cmd: '/securitylog set/clear/show', desc: 'Configure security log channel and view settings', perm: null },
+    { cmd: '/securitylog mode', desc: 'Choose delivery: channel, owners, or both', perm: null },
+    { cmd: '/securitylog toggle', desc: 'Enable or disable security logging as a whole', perm: null },
+    {
+      cmd: '/modlog set/mode/toggle/show',
+      desc: 'Configure moderation action logging (bans, kicks, mutes, role changes)',
+      perm: null,
+    },
+    { cmd: '/logchannels', desc: 'Show configured log channels', perm: null },
+    { cmd: '/logconfig', desc: 'Show status of all logging categories', perm: null },
+    { cmd: '/securityreport', desc: 'Who triggered permission/hierarchy/missing-command events', perm: null },
+    { cmd: '/channelsync', desc: 'Sync channels to their category permissions', perm: 'Manage Channels' },
   ],
   'Media Tools': [
-    ['/- removebg', 'Remove image background (API key required).'],
-    ['/- transcribe', 'Transcribe an attached audio file (OpenAI API).'],
-    ['/- summarize', 'Summarize provided text or a text file (OpenAI).'],
+    { cmd: '/removebg', desc: 'Remove image background (API key required)', perm: null },
+    { cmd: '/transcribe', desc: 'Transcribe an attached audio file (OpenAI API)', perm: null },
+    { cmd: '/summarize', desc: 'Summarize provided text or a text file (OpenAI)', perm: null },
   ],
-  'System': [
-    ['/- botinfo', 'Show instance, mode, commands loaded, uptime.'],
-    ['/- webhooks', 'List server webhooks and their creators. Requires Manage Webhooks.'],
+  System: [
+    { cmd: '/botinfo', desc: 'Show instance, mode, commands loaded, uptime', perm: null },
+    { cmd: '/webhooks', desc: 'List server webhooks and their creators', perm: 'Manage Webhooks' },
   ],
   'Owner Only': [
-    ['/- adminlist', '\u200B'],
-    ['/- dmdiag test', 'Tests the bot’s direct messages and blacklisted roles'],
-    ['/- dmdiag role', 'Tests the bot’s direct messages and blacklisted roles'],
+    { cmd: '/adminlist', desc: '\u200B', perm: null },
+    { cmd: '/dmdiag test', desc: 'Tests the bot’s direct messages and blacklisted roles', perm: null },
+    { cmd: '/dmdiag role', desc: 'Tests the bot’s direct messages and blacklisted roles', perm: null },
   ],
 };
 
 function buildEmbed(categoryName, includeOwner, guildId) {
-  const embed = new EmbedBuilder()
-    .setTitle('Bot Help');
+  const embed = new EmbedBuilder().setTitle('Bot Help');
   try {
     const { applyDefaultColour } = require('../utils/guildColourStore');
     applyDefaultColour(embed, guildId);
@@ -74,59 +83,69 @@ function buildEmbed(categoryName, includeOwner, guildId) {
       embed.setDescription('Owner-only commands are hidden.');
       return embed;
     }
-    embed.setDescription(`${categoryName}`);
-    const fields = categories[categoryName].map(([name, value]) => ({ name: name.replace('/-', '/'), value, inline: false }));
+    embed.setDescription(categoryName);
+    const fields = categories[categoryName].map(({ cmd, desc, perm }) => ({
+      name: cmd,
+      value: `${desc}${perm ? `\nRequires: ${perm}` : ''}`,
+      inline: false,
+    }));
     embed.addFields(fields);
     return embed;
   }
 
-  embed.setDescription('Overview of available commands (grouped)');
-  for (const [cat, items] of Object.entries(categories)) {
-    if (cat === 'Owner Only' && !includeOwner) continue;
-    const value = items.map(([name, value]) => `• ${name.replace('/-', '/') } — ${value}`).join('\n');
-    embed.addFields({ name: cat, value, inline: false });
-  }
+  embed.setDescription('Select a category from the menu below.');
+  const cats = Object.keys(categories).filter(
+    (cat) => !(cat === 'Owner Only' && !includeOwner)
+  );
+  const value = cats.map((c) => `• ${c}`).join('\n');
+  embed.addFields({ name: 'Categories', value });
   return embed;
 }
 
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('help')
-    .setDescription('Get help with the bot')
-    .addStringOption(opt =>
-      opt.setName('category')
-        .setDescription('Filter by category')
-        .addChoices(
-          { name: 'Moderation', value: 'Moderation' },
-          { name: 'Roles', value: 'Roles' },
-          { name: 'Emoji & Stickers', value: 'Emoji & Stickers' },
-          { name: 'Embeds', value: 'Embeds' },
-          { name: 'Member Stats', value: 'Member Stats' },
-          { name: 'Security', value: 'Security' },
-          { name: 'Media Tools', value: 'Media Tools' },
-          { name: 'System', value: 'System' },
-          { name: 'Owner Only', value: 'Owner Only' },
-        )
-        .setRequired(false)
-    ),
+    .setDescription('Get help with the bot'),
 
   async execute(interaction) {
-    const cat = interaction.options.getString('category');
     const owner = isOwner(interaction.user.id);
+    const embed = buildEmbed(null, owner, interaction.guildId);
 
-    if (cat === 'Owner Only' && !owner) {
-      return interaction.reply({ content: 'This category is only visible to bot owners.', ephemeral: true });
-    }
+    const options = Object.keys(categories)
+      .filter((c) => !(c === 'Owner Only' && !owner))
+      .map((c) => ({ label: c, value: c }));
 
-    const embed = buildEmbed(cat, owner, interaction.guildId);
-    try {
-      await interaction.reply({ embeds: [embed] });
-    } catch (_) {
-      try {
-        if (interaction.channel && interaction.channel.send) {
-          await interaction.channel.send({ embeds: [embed] });
-        }
-      } catch (_) {}
-    }
+    const menu = new StringSelectMenuBuilder()
+      .setCustomId('help-category')
+      .setPlaceholder('Choose a category')
+      .addOptions(options);
+
+    const row = new ActionRowBuilder().addComponents(menu);
+
+    const message = await interaction.reply({
+      embeds: [embed],
+      components: [row],
+      fetchReply: true,
+    });
+
+    const collector = message.createMessageComponentCollector({
+      componentType: ComponentType.StringSelect,
+      time: 60_000,
+    });
+
+    collector.on('collect', async (i) => {
+      if (i.user.id !== interaction.user.id) {
+        return i.reply({ content: 'This menu is not for you.', ephemeral: true });
+      }
+      const selected = i.values[0];
+      const catEmbed = buildEmbed(selected, owner, interaction.guildId);
+      await i.update({ embeds: [catEmbed], components: [row] });
+    });
+
+    collector.on('end', () => {
+      row.components[0].setDisabled(true);
+      message.edit({ components: [row] }).catch(() => {});
+    });
   },
 };
+


### PR DESCRIPTION
## Summary
- revamp `/help` to show categories with a select menu
- filter owner-only category from non-owner users
- display commands with descriptions and required permissions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be5197785c8331b535d6b9c21684c0