### PR TITLE
Add anonymous confession command and handlers

### DIFF
--- a/src/commands/confessconfig.js
+++ b/src/commands/confessconfig.js
@@ -1,0 +1,71 @@
+const {
+  SlashCommandBuilder,
+  PermissionFlagsBits,
+  ChannelType,
+  EmbedBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+} = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('confessconfig')
+    .setDescription('Send the anonymous confession prompt to a channel')
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
+    .addChannelOption((option) =>
+      option
+        .setName('channel')
+        .setDescription('Channel to post the confession button in')
+        .addChannelTypes(ChannelType.GuildText, ChannelType.GuildAnnouncement)
+        .setRequired(true)
+    ),
+
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ content: 'Use this command in a server.', ephemeral: true });
+    }
+
+    if (!interaction.member.permissions?.has(PermissionFlagsBits.ManageGuild)) {
+      return interaction.reply({ content: 'You need Manage Server to use this command.', ephemeral: true });
+    }
+
+    const channel = interaction.options.getChannel('channel', true);
+
+    if (!channel?.isTextBased?.()) {
+      return interaction.reply({ content: 'Please choose a text-based channel.', ephemeral: true });
+    }
+
+    const me = interaction.guild.members.me;
+    const perms = channel.permissionsFor(me);
+
+    if (!perms?.has(PermissionFlagsBits.SendMessages)) {
+      return interaction.reply({ content: `I cannot send messages in ${channel}.`, ephemeral: true });
+    }
+
+    const embed = new EmbedBuilder()
+      .setTitle('Anonymous Confessions')
+      .setDescription('Share something anonymously by pressing the button below.')
+      .setTimestamp();
+
+    try {
+      const { applyDefaultColour } = require('../utils/guildColourStore');
+      applyDefaultColour(embed, interaction.guildId);
+    } catch (_) {}
+
+    const button = new ButtonBuilder()
+      .setCustomId(`confess:open:${channel.id}`)
+      .setLabel('Confess Anonymously')
+      .setStyle(ButtonStyle.Success);
+
+    const row = new ActionRowBuilder().addComponents(button);
+
+    try {
+      await channel.send({ embeds: [embed], components: [row] });
+    } catch (error) {
+      return interaction.reply({ content: `Failed to send the confession prompt: ${error.message}`, ephemeral: true });
+    }
+
+    return interaction.reply({ content: `Sent confession prompt to ${channel}.`, ephemeral: true });
+  },
+};

--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -178,10 +178,86 @@ module.exports = {
                 }
                 return;
             }
+            if (typeof interaction.customId === 'string' && interaction.customId.startsWith('confess:open:')) {
+                if (!interaction.inGuild()) return;
+
+                const channelId = interaction.customId.slice('confess:open:'.length);
+                let channel = null;
+                try { channel = await interaction.guild.channels.fetch(channelId); } catch (_) {}
+                if (!channel || !channel.isTextBased?.()) {
+                    try { await interaction.reply({ content: 'That confession panel is no longer available.', ephemeral: true }); } catch (_) {}
+                    return;
+                }
+
+                const modal = new ModalBuilder()
+                    .setCustomId(`confess:submit:${channelId}`)
+                    .setTitle('Anonymous Confession');
+                const input = new TextInputBuilder()
+                    .setCustomId('confess:text')
+                    .setLabel('Write an anonymous confession')
+                    .setStyle(TextInputStyle.Paragraph)
+                    .setMinLength(1)
+                    .setMaxLength(1000)
+                    .setPlaceholder('Write an anonymous confession')
+                    .setRequired(true);
+                const row = new ActionRowBuilder().addComponents(input);
+                modal.addComponents(row);
+
+                try {
+                    await interaction.showModal(modal);
+                } catch (_) {
+                    try { await interaction.reply({ content: 'Could not open the confession form. Please try again.', ephemeral: true }); } catch (_) {}
+                }
+                return;
+            }
         }
 
         // Handle modal submissions
         if (interaction.isModalSubmit()) {
+            if (typeof interaction.customId === 'string' && interaction.customId.startsWith('confess:submit:')) {
+                if (!interaction.inGuild()) return;
+
+                const channelId = interaction.customId.slice('confess:submit:'.length);
+                const confession = (interaction.fields.getTextInputValue('confess:text') || '').trim();
+
+                if (!confession) {
+                    try { await interaction.reply({ content: 'Please enter a confession before submitting.', ephemeral: true }); } catch (_) {}
+                    return;
+                }
+
+                let channel = null;
+                try { channel = await interaction.guild.channels.fetch(channelId); } catch (_) {}
+
+                if (!channel || !channel.isTextBased?.()) {
+                    try { await interaction.reply({ content: 'The confession channel is no longer available. Please inform an admin.', ephemeral: true }); } catch (_) {}
+                    return;
+                }
+
+                const sanitized = confession
+                    .replace(/@/g, '@\u200b')
+                    .replace(/#/g, '#\u200b')
+                    .replace(/&/g, '&\u200b');
+
+                const embed = new EmbedBuilder()
+                    .setTitle('Anonymous Confession')
+                    .setDescription(sanitized)
+                    .setTimestamp();
+
+                try {
+                    const { applyDefaultColour } = require('../utils/guildColourStore');
+                    applyDefaultColour(embed, interaction.guildId);
+                } catch (_) {}
+
+                try {
+                    await channel.send({ embeds: [embed] });
+                } catch (_) {
+                    try { await interaction.reply({ content: 'Failed to send your confession. Please try again later.', ephemeral: true }); } catch (_) {}
+                    return;
+                }
+
+                try { await interaction.reply({ content: 'Your confession has been sent anonymously.', ephemeral: true }); } catch (_) {}
+                return;
+            }
             // Welcome embed setup modal
             if (typeof interaction.customId === 'string' && interaction.customId.startsWith('welcome:embed:')) {
                 if (!interaction.inGuild()) return;


### PR DESCRIPTION
## Summary
- add a `/confessconfig` slash command for admins to send the anonymous confession panel to a chosen channel
- handle confession button presses and modal submissions to deliver sanitized anonymous confession embeds

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c87eace4d48331911416051161100e