### PR TITLE
Add slash command to manage server tag

### DIFF
--- a/src/commands/servertag.js
+++ b/src/commands/servertag.js
@@ -1,0 +1,71 @@
+const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
+const { MAX_TAG_LENGTH, getServerTag, setServerTag, clearServerTag } = require('../utils/serverTagStore');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('servertag')
+    .setDescription('View or update the saved server tag')
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
+    .addSubcommand(sub =>
+      sub
+        .setName('set')
+        .setDescription('Update the server tag')
+        .addStringOption(opt =>
+          opt
+            .setName('tag')
+            .setDescription(`New server tag (max ${MAX_TAG_LENGTH} characters)`)
+            .setRequired(true)
+            .setMaxLength(MAX_TAG_LENGTH)
+        )
+    )
+    .addSubcommand(sub =>
+      sub
+        .setName('show')
+        .setDescription('Show the currently saved server tag')
+    )
+    .addSubcommand(sub =>
+      sub
+        .setName('clear')
+        .setDescription('Remove the saved server tag')
+    ),
+
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ content: 'Use this in a server.', ephemeral: true });
+    }
+
+    if (!interaction.member.permissions?.has(PermissionFlagsBits.ManageGuild)) {
+      return interaction.reply({ content: 'You need Manage Server to use this command.', ephemeral: true });
+    }
+
+    const sub = interaction.options.getSubcommand();
+
+    if (sub === 'set') {
+      const raw = interaction.options.getString('tag', true);
+      try {
+        const saved = await setServerTag(interaction.guildId, raw);
+        return interaction.reply({ content: `Server tag updated to: **${saved}**`, ephemeral: true });
+      } catch (err) {
+        return interaction.reply({ content: `Error: ${err.message}`, ephemeral: true });
+      }
+    }
+
+    if (sub === 'show') {
+      const tag = getServerTag(interaction.guildId);
+      if (!tag) {
+        return interaction.reply({ content: 'No server tag is set.', ephemeral: true });
+      }
+      return interaction.reply({ content: `Current server tag: **${tag}**`, ephemeral: true });
+    }
+
+    if (sub === 'clear') {
+      const removed = await clearServerTag(interaction.guildId);
+      return interaction.reply({
+        content: removed ? 'Server tag cleared.' : 'No server tag was set.',
+        ephemeral: true,
+      });
+    }
+
+    return interaction.reply({ content: 'Unknown subcommand.', ephemeral: true });
+  },
+};

--- a/src/utils/serverTagStore.js
+++ b/src/utils/serverTagStore.js
@@ -1,0 +1,86 @@
+const fs = require('fs');
+const path = require('path');
+
+const overrideDir = (process.env.DUSSCORD_DATA_DIR || '').trim();
+const dataDir = overrideDir ? path.resolve(overrideDir) : path.join(__dirname, '..', 'data');
+const STORE_FILE = path.join(dataDir, 'server_tags.json');
+const MAX_TAG_LENGTH = 32;
+
+function ensureStore() {
+  try {
+    if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true });
+    if (!fs.existsSync(STORE_FILE)) {
+      fs.writeFileSync(STORE_FILE, JSON.stringify({ guilds: {} }, null, 2), 'utf8');
+    }
+  } catch (err) {
+    // best effort; downstream reads/writes will surface errors if needed
+  }
+}
+
+function readStore() {
+  ensureStore();
+  try {
+    const raw = fs.readFileSync(STORE_FILE, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return { guilds: {} };
+    if (!parsed.guilds || typeof parsed.guilds !== 'object') parsed.guilds = {};
+    return parsed;
+  } catch {
+    return { guilds: {} };
+  }
+}
+
+async function writeStore(store) {
+  ensureStore();
+  const clean = store && typeof store === 'object' ? store : { guilds: {} };
+  if (!clean.guilds || typeof clean.guilds !== 'object') clean.guilds = {};
+  await fs.promises.mkdir(dataDir, { recursive: true });
+  await fs.promises.writeFile(STORE_FILE, JSON.stringify(clean, null, 2), 'utf8');
+}
+
+function normaliseTag(input) {
+  if (typeof input !== 'string') throw new Error('Tag must be a string.');
+  const trimmed = input.trim();
+  if (!trimmed.length) throw new Error('Tag cannot be empty or whitespace.');
+  if (trimmed.length > MAX_TAG_LENGTH) {
+    throw new Error(`Tag must be at most ${MAX_TAG_LENGTH} characters long.`);
+  }
+  return trimmed;
+}
+
+function getServerTag(guildId) {
+  const store = readStore();
+  const rec = store.guilds?.[guildId];
+  if (!rec || typeof rec !== 'object') return null;
+  const tag = typeof rec.tag === 'string' ? rec.tag.trim() : '';
+  return tag.length ? tag : null;
+}
+
+async function setServerTag(guildId, tag) {
+  const cleaned = normaliseTag(tag);
+  const store = readStore();
+  if (!store.guilds || typeof store.guilds !== 'object') store.guilds = {};
+  if (!store.guilds[guildId] || typeof store.guilds[guildId] !== 'object') store.guilds[guildId] = {};
+  store.guilds[guildId].tag = cleaned;
+  await writeStore(store);
+  return cleaned;
+}
+
+async function clearServerTag(guildId) {
+  const store = readStore();
+  if (!store.guilds || typeof store.guilds !== 'object') store.guilds = {};
+  const rec = store.guilds[guildId];
+  if (!rec || typeof rec !== 'object' || typeof rec.tag === 'undefined') return false;
+  const hadValue = typeof rec.tag === 'string' && rec.tag.trim().length > 0;
+  delete rec.tag;
+  if (!Object.keys(rec).length) delete store.guilds[guildId];
+  await writeStore(store);
+  return hadValue;
+}
+
+module.exports = {
+  MAX_TAG_LENGTH,
+  getServerTag,
+  setServerTag,
+  clearServerTag,
+};

--- a/tests/serverTagStore.test.js
+++ b/tests/serverTagStore.test.js
@@ -1,0 +1,48 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const modulePath = require.resolve('../src/utils/serverTagStore');
+
+async function withTempStore(fn) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'servertag-'));
+  delete require.cache[modulePath];
+  process.env.DUSSCORD_DATA_DIR = tmpDir;
+  const store = require(modulePath);
+  try {
+    await fn(store, tmpDir);
+  } finally {
+    delete require.cache[modulePath];
+    delete process.env.DUSSCORD_DATA_DIR;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+test('server tag store set/get/clear cycle', async () => {
+  await withTempStore(async store => {
+    assert.equal(store.getServerTag('123'), null);
+    const saved = await store.setServerTag('123', 'My Server');
+    assert.equal(saved, 'My Server');
+    assert.equal(store.getServerTag('123'), 'My Server');
+    const file = path.join(process.env.DUSSCORD_DATA_DIR, 'server_tags.json');
+    assert.ok(fs.existsSync(file));
+    const removed = await store.clearServerTag('123');
+    assert.equal(removed, true);
+    assert.equal(store.getServerTag('123'), null);
+    const removedAgain = await store.clearServerTag('123');
+    assert.equal(removedAgain, false);
+  });
+});
+
+test('server tag validation trims and limits length', async () => {
+  await withTempStore(async store => {
+    await assert.rejects(() => store.setServerTag('1', '   '), /cannot be empty/i);
+    const max = store.MAX_TAG_LENGTH;
+    await assert.rejects(() => store.setServerTag('1', 'a'.repeat(max + 1)), /at most/);
+    const saved = await store.setServerTag('1', '  Hello World  ');
+    assert.equal(saved, 'Hello World');
+    assert.equal(store.getServerTag('1'), 'Hello World');
+  });
+});


### PR DESCRIPTION
## Summary
- add a `/servertag` slash command that lets managers set, show, or clear the saved server tag
- implement a persistent server tag store with validation and optional data directory override
- cover the new store with unit tests that exercise persistence and validation paths

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c888f720408331a8bfad050a28ac6d