### PR TITLE
Add Drugscord Bag reward system and timeout command

### DIFF
--- a/src/commands/drugscordbag.js
+++ b/src/commands/drugscordbag.js
@@ -1,0 +1,141 @@
+const { SlashCommandBuilder, PermissionsBitField } = require('discord.js');
+const tokenStore = require('../utils/messageTokenStore');
+const securityLogger = require('../utils/securityLogger');
+const modLogger = require('../utils/modLogger');
+
+const BAG_LABEL = 'Drugscord Bag';
+const MAX_MINUTES = 10;
+const PROTECTED_PERMISSIONS = new PermissionsBitField([
+  PermissionsBitField.Flags.Administrator,
+  PermissionsBitField.Flags.ModerateMembers,
+  PermissionsBitField.Flags.ManageGuild,
+  PermissionsBitField.Flags.ManageRoles,
+  PermissionsBitField.Flags.KickMembers,
+  PermissionsBitField.Flags.BanMembers,
+]);
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('drugscordbag')
+    .setDescription('Spend a Drugscord Bag to timeout a user for up to 10 minutes.')
+    .addUserOption(opt =>
+      opt
+        .setName('target')
+        .setDescription('Member to timeout')
+        .setRequired(true)
+    )
+    .addIntegerOption(opt =>
+      opt
+        .setName('duration')
+        .setDescription('Timeout duration in minutes (1-10). Defaults to 10 minutes.')
+        .setMinValue(1)
+        .setMaxValue(MAX_MINUTES)
+    )
+    .addStringOption(opt =>
+      opt
+        .setName('reason')
+        .setDescription('Reason for spending the bag (optional, max 200 characters).')
+        .setMaxLength(200)
+    ),
+
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ content: 'Use this command in a server.', ephemeral: true });
+    }
+
+    await interaction.deferReply({ ephemeral: true });
+
+    const me = interaction.guild.members.me;
+    if (!me.permissions.has(PermissionsBitField.Flags.ModerateMembers)) {
+      await securityLogger.logPermissionDenied(interaction, 'drugscordbag', 'Bot missing Moderate Members');
+      return interaction.editReply({ content: 'I need the Moderate Members permission to spend Drugscord Bags.' });
+    }
+
+    const balance = tokenStore.getBalance(interaction.guild.id, interaction.user.id);
+    if (balance <= 0) {
+      const progress = tokenStore.getProgress(interaction.guild.id, interaction.user.id);
+      const remaining = progress.messagesUntilNext || tokenStore.AWARD_THRESHOLD;
+      return interaction.editReply({
+        content: `You do not have any ${BAG_LABEL}s. Send ${remaining} more message${remaining === 1 ? '' : 's'} to earn your next one.`,
+      });
+    }
+
+    const targetUser = interaction.options.getUser('target', true);
+    if (targetUser.id === interaction.user.id) {
+      return interaction.editReply({ content: "You can't use a Drugscord Bag on yourself." });
+    }
+    if (targetUser.id === interaction.client.user.id) {
+      return interaction.editReply({ content: "You can't spend a Drugscord Bag on me." });
+    }
+    if (targetUser.bot) {
+      return interaction.editReply({ content: "You can't use a Drugscord Bag on a bot." });
+    }
+
+    let targetMember;
+    try {
+      targetMember = await interaction.guild.members.fetch(targetUser.id);
+    } catch (_) {
+      return interaction.editReply({ content: 'That user is not in this server.' });
+    }
+
+    if (targetMember.permissions.has(PROTECTED_PERMISSIONS)) {
+      await securityLogger.logPermissionDenied(interaction, 'drugscordbag', 'Target has protected permissions', [
+        { name: 'Target', value: `${targetUser.tag} (${targetUser.id})`, inline: false },
+      ]);
+      return interaction.editReply({ content: 'You cannot spend Drugscord Bags on moderators or administrators.' });
+    }
+
+    const meHigher = me.roles.highest.comparePositionTo(targetMember.roles.highest) > 0;
+    if (!meHigher || !targetMember.moderatable) {
+      await securityLogger.logHierarchyViolation(interaction, 'drugscordbag', targetMember, 'Bot lower than target or not moderatable');
+      return interaction.editReply({ content: "I can't timeout that member due to role hierarchy or permissions." });
+    }
+
+    const requesterHigher = interaction.member.roles.highest.comparePositionTo(targetMember.roles.highest) > 0
+      || interaction.guild.ownerId === interaction.user.id;
+    if (!requesterHigher) {
+      await securityLogger.logHierarchyViolation(interaction, 'drugscordbag', targetMember, 'Requester lower or equal to target');
+      return interaction.editReply({ content: "You can't timeout someone with an equal or higher role." });
+    }
+
+    const durationInput = interaction.options.getInteger('duration');
+    let durationMinutes = durationInput ?? MAX_MINUTES;
+    if (!Number.isFinite(durationMinutes) || durationMinutes <= 0) durationMinutes = MAX_MINUTES;
+    if (durationMinutes > MAX_MINUTES) durationMinutes = MAX_MINUTES;
+    const durationMs = durationMinutes * 60_000;
+
+    const reasonRaw = (interaction.options.getString('reason') || '').trim();
+    const reason = reasonRaw.slice(0, 200);
+
+    const spent = await tokenStore.consumeToken(interaction.guild.id, interaction.user.id);
+    if (!spent) {
+      return interaction.editReply({ content: `You no longer have a ${BAG_LABEL} to spend.` });
+    }
+
+    try {
+      const auditReasonParts = [`${BAG_LABEL} used by ${interaction.user.tag} (${interaction.user.id})`];
+      if (reason) auditReasonParts.push(`Reason: ${reason}`);
+      const auditReason = auditReasonParts.join(' | ').slice(0, 512);
+      await targetMember.timeout(durationMs, auditReason);
+
+      const remainingBags = tokenStore.getBalance(interaction.guild.id, interaction.user.id);
+      const humanReason = reason || 'No reason provided';
+      const baseMessage = `Timed out ${targetUser.tag} for ${durationMinutes} minute${durationMinutes === 1 ? '' : 's'} using a ${BAG_LABEL}.`;
+      const replyMessage = `${baseMessage} Remaining bags: ${remainingBags}. Reason: ${humanReason}`;
+      await interaction.editReply({ content: replyMessage });
+
+      try {
+        await modLogger.log(interaction, 'Drugscord Bag Timeout', [
+          { name: 'Target', value: `${targetUser.tag} (${targetUser.id})`, inline: false },
+          { name: 'Duration', value: `${durationMinutes} minute${durationMinutes === 1 ? '' : 's'}`, inline: true },
+          { name: 'Reason', value: humanReason, inline: false },
+          { name: 'Remaining Bags', value: String(remainingBags), inline: true },
+        ], 0x2ecc71);
+      } catch (_) {}
+    } catch (err) {
+      await tokenStore.addTokens(interaction.guild.id, interaction.user.id, 1);
+      const errorMsg = err?.message ? `Failed to timeout the member: ${err.message}` : 'Failed to timeout the member.';
+      await interaction.editReply({ content: `${errorMsg} Your ${BAG_LABEL} was refunded.` });
+    }
+  },
+};

--- a/src/events/messageCreate.drugscordBags.js
+++ b/src/events/messageCreate.drugscordBags.js
@@ -1,0 +1,39 @@
+const { Events } = require('discord.js');
+const bagStore = require('../utils/messageTokenStore');
+
+const BAG_LABEL = 'Drugscord Bag';
+
+module.exports = {
+  name: Events.MessageCreate,
+  async execute(message) {
+    try {
+      if (!message?.guild) return;
+      if (message.author?.bot) return;
+
+      const result = await bagStore.incrementMessage(message.guild.id, message.author.id);
+      if (!result || !result.awarded) return;
+
+      const totalBags = result.tokens;
+      const awardedBags = result.awarded;
+      const pluralAward = awardedBags === 1 ? '' : 's';
+      const pluralTotal = totalBags === 1 ? '' : 's';
+      const nextIn = result.messagesUntilNext || bagStore.AWARD_THRESHOLD;
+      const base = `You just earned ${awardedBags} ${BAG_LABEL}${pluralAward} in ${message.guild.name}!`;
+      const totalLine = `You now have ${totalBags} ${BAG_LABEL}${pluralTotal}.`;
+      const nextLine = `Next bag in ${nextIn} message${nextIn === 1 ? '' : 's'}.`;
+      const content = `${base} ${totalLine} ${nextLine}`.slice(0, 1900);
+
+      try {
+        await message.author.send({ content });
+      } catch (_) {
+        try {
+          await message.reply({ content, allowedMentions: { repliedUser: false } });
+        } catch (_) {
+          // ignore if we cannot notify the user
+        }
+      }
+    } catch (err) {
+      console.error('Failed to process Drugscord Bag increment', err);
+    }
+  },
+};

--- a/src/utils/messageTokenStore.js
+++ b/src/utils/messageTokenStore.js
@@ -1,0 +1,148 @@
+const fs = require('fs');
+const path = require('path');
+
+const overrideDir = (process.env.DUSSCORD_DATA_DIR || '').trim();
+const dataDir = overrideDir ? path.resolve(overrideDir) : path.join(__dirname, '..', 'data');
+const STORE_FILE = path.join(dataDir, 'message_tokens.json');
+const AWARD_THRESHOLD = 200;
+
+let cache = null;
+
+function ensureStoreFile() {
+  try {
+    if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true });
+    if (!fs.existsSync(STORE_FILE)) {
+      fs.writeFileSync(STORE_FILE, JSON.stringify({ guilds: {} }, null, 2), 'utf8');
+    }
+  } catch (err) {
+    console.error('Failed to initialise message token store', err);
+  }
+}
+
+function loadStore() {
+  if (cache) return cache;
+  ensureStoreFile();
+  try {
+    const raw = fs.readFileSync(STORE_FILE, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') {
+      cache = { guilds: {} };
+    } else {
+      if (!parsed.guilds || typeof parsed.guilds !== 'object') parsed.guilds = {};
+      cache = parsed;
+    }
+  } catch (err) {
+    cache = { guilds: {} };
+  }
+  return cache;
+}
+
+async function saveStore() {
+  ensureStoreFile();
+  const safe = cache && typeof cache === 'object' ? cache : { guilds: {} };
+  if (!safe.guilds || typeof safe.guilds !== 'object') safe.guilds = {};
+  await fs.promises.mkdir(dataDir, { recursive: true });
+  await fs.promises.writeFile(STORE_FILE, JSON.stringify(safe, null, 2), 'utf8');
+}
+
+function ensureRecord(guildId, userId) {
+  const store = loadStore();
+  if (!store.guilds[guildId] || typeof store.guilds[guildId] !== 'object') {
+    store.guilds[guildId] = { users: {} };
+  }
+  const guild = store.guilds[guildId];
+  if (!guild.users || typeof guild.users !== 'object') guild.users = {};
+  if (!guild.users[userId] || typeof guild.users[userId] !== 'object') {
+    guild.users[userId] = {
+      totalMessages: 0,
+      progress: 0,
+      tokens: 0,
+    };
+  }
+  const rec = guild.users[userId];
+  if (!Number.isFinite(rec.totalMessages)) rec.totalMessages = 0;
+  if (!Number.isFinite(rec.progress) || rec.progress < 0) rec.progress = 0;
+  if (!Number.isFinite(rec.tokens) || rec.tokens < 0) rec.tokens = 0;
+  rec.totalMessages = Math.floor(rec.totalMessages);
+  rec.progress = Math.floor(rec.progress);
+  rec.tokens = Math.floor(rec.tokens);
+  if (rec.progress >= AWARD_THRESHOLD) {
+    const extra = Math.floor(rec.progress / AWARD_THRESHOLD);
+    rec.progress -= extra * AWARD_THRESHOLD;
+    rec.tokens += extra;
+  }
+  return rec;
+}
+
+async function incrementMessage(guildId, userId) {
+  if (!guildId || !userId) return null;
+  const rec = ensureRecord(guildId, userId);
+  rec.totalMessages += 1;
+  rec.progress += 1;
+  let awarded = 0;
+  while (rec.progress >= AWARD_THRESHOLD) {
+    rec.progress -= AWARD_THRESHOLD;
+    rec.tokens += 1;
+    awarded += 1;
+  }
+  await saveStore();
+  return {
+    awarded,
+    tokens: rec.tokens,
+    totalMessages: rec.totalMessages,
+    progress: rec.progress,
+    messagesUntilNext: AWARD_THRESHOLD - rec.progress,
+  };
+}
+
+async function consumeToken(guildId, userId) {
+  if (!guildId || !userId) return false;
+  const rec = ensureRecord(guildId, userId);
+  if (rec.tokens <= 0) return false;
+  rec.tokens -= 1;
+  await saveStore();
+  return true;
+}
+
+async function addTokens(guildId, userId, amount = 1) {
+  if (!guildId || !userId) return 0;
+  const num = Number(amount) || 0;
+  if (num <= 0) return getBalance(guildId, userId);
+  const rec = ensureRecord(guildId, userId);
+  rec.tokens += num;
+  await saveStore();
+  return rec.tokens;
+}
+
+function getBalance(guildId, userId) {
+  if (!guildId || !userId) return 0;
+  const rec = ensureRecord(guildId, userId);
+  return rec.tokens;
+}
+
+function getProgress(guildId, userId) {
+  if (!guildId || !userId) {
+    return {
+      totalMessages: 0,
+      tokens: 0,
+      progress: 0,
+      messagesUntilNext: AWARD_THRESHOLD,
+    };
+  }
+  const rec = ensureRecord(guildId, userId);
+  return {
+    totalMessages: rec.totalMessages,
+    tokens: rec.tokens,
+    progress: rec.progress,
+    messagesUntilNext: AWARD_THRESHOLD - rec.progress,
+  };
+}
+
+module.exports = {
+  AWARD_THRESHOLD,
+  incrementMessage,
+  consumeToken,
+  addTokens,
+  getBalance,
+  getProgress,
+};

--- a/tests/messageTokenStore.test.js
+++ b/tests/messageTokenStore.test.js
@@ -1,0 +1,71 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const modulePath = require.resolve('../src/utils/messageTokenStore');
+
+async function withTempStore(fn) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bags-'));
+  delete require.cache[modulePath];
+  process.env.DUSSCORD_DATA_DIR = tmpDir;
+  const store = require(modulePath);
+  try {
+    await fn(store, tmpDir);
+  } finally {
+    delete require.cache[modulePath];
+    delete process.env.DUSSCORD_DATA_DIR;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+test('awards a Drugscord Bag every 200 messages', async () => {
+  await withTempStore(async store => {
+    const guildId = 'guild';
+    const userId = 'user';
+    for (let i = 0; i < 199; i++) {
+      const res = await store.incrementMessage(guildId, userId);
+      assert.equal(res.awarded, 0);
+      assert.equal(res.tokens, 0);
+    }
+    const result = await store.incrementMessage(guildId, userId);
+    assert.equal(result.awarded, 1);
+    assert.equal(result.tokens, 1);
+    assert.equal(result.progress, 0);
+    assert.equal(result.messagesUntilNext, store.AWARD_THRESHOLD);
+
+    const stats = store.getProgress(guildId, userId);
+    assert.equal(stats.tokens, 1);
+    assert.equal(stats.progress, 0);
+    assert.equal(stats.messagesUntilNext, store.AWARD_THRESHOLD);
+
+    const file = path.join(process.env.DUSSCORD_DATA_DIR, 'message_tokens.json');
+    assert.ok(fs.existsSync(file));
+    const saved = JSON.parse(fs.readFileSync(file, 'utf8'));
+    assert.equal(saved.guilds[guildId].users[userId].tokens, 1);
+  });
+});
+
+test('consuming and refunding Drugscord Bags updates balance', async () => {
+  await withTempStore(async store => {
+    const guildId = 'guild';
+    const userId = 'user';
+
+    for (let i = 0; i < store.AWARD_THRESHOLD; i++) {
+      await store.incrementMessage(guildId, userId);
+    }
+    assert.equal(store.getBalance(guildId, userId), 1);
+
+    const spent = await store.consumeToken(guildId, userId);
+    assert.equal(spent, true);
+    assert.equal(store.getBalance(guildId, userId), 0);
+
+    const spentAgain = await store.consumeToken(guildId, userId);
+    assert.equal(spentAgain, false);
+
+    const refunded = await store.addTokens(guildId, userId, 2);
+    assert.equal(refunded, 2);
+    assert.equal(store.getBalance(guildId, userId), 2);
+  });
+});


### PR DESCRIPTION
## Summary
- track per-guild message counts and persist Drugscord Bag balances when users chat
- notify members upon earning bags and add a /drugscordbag command to spend them with hierarchy and permission safeguards
- cover the token store with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9e73b85f08331b3d0fc963b64c467