### PR TITLE
Allow hex input when setting default embed colour

### DIFF
--- a/src/utils/guildColourStore.js
+++ b/src/utils/guildColourStore.js
@@ -62,7 +62,17 @@ function getDefaultColour(guildId) {
 }
 
 async function setDefaultColour(guildId, input) {
-  const parsed = input === null ? null : parseColour(input);
+  let parsed;
+  if (input === null) {
+    parsed = null;
+  } else if (typeof input === 'number') {
+    if (!Number.isInteger(input) || input < 0 || input > 0xffffff) {
+      throw new Error("Invalid colour number. Use values between 0x000000 and 0xFFFFFF.");
+    }
+    parsed = input;
+  } else {
+    parsed = parseColour(input);
+  }
   const store = readStore();
   if (!store.guilds[guildId]) store.guilds[guildId] = {};
   if (parsed == null) delete store.guilds[guildId].colour; else store.guilds[guildId].colour = parsed;

--- a/tests/guildColourStore.test.js
+++ b/tests/guildColourStore.test.js
@@ -1,0 +1,29 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dusscord-guild-colour-'));
+process.env.DUSSCORD_DATA_DIR = tempDir;
+
+const modulePath = require.resolve('../src/utils/guildColourStore');
+delete require.cache[modulePath];
+const {
+  setDefaultColour,
+  getDefaultColour,
+  parseColour,
+} = require(modulePath);
+
+test('setDefaultColour accepts hex string input', async () => {
+  const saved = await setDefaultColour('guild-hex', '#1a2b3c');
+  assert.strictEqual(saved, parseColour('#1a2b3c'));
+  assert.strictEqual(getDefaultColour('guild-hex'), parseColour('#1a2b3c'));
+});
+
+test('setDefaultColour accepts numeric input', async () => {
+  const value = parseColour('#654321');
+  const saved = await setDefaultColour('guild-number', value);
+  assert.strictEqual(saved, value);
+  assert.strictEqual(getDefaultColour('guild-number'), value);
+});

--- a/tests/logconfig.test.js
+++ b/tests/logconfig.test.js
@@ -1,5 +1,11 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 const test = require('node:test');
 const assert = require('node:assert/strict');
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dusscord-logconfig-'));
+process.env.DUSSCORD_DATA_DIR = tempDir;
 
 const logconfig = require('../src/commands/logconfig');
 const securityLogStore = require('../src/utils/securityLogStore');


### PR DESCRIPTION
## Summary
- allow `setDefaultColour` to persist already-parsed colour integers so hex input from the slash command is accepted
- point logconfig tests at an isolated data directory to avoid polluting the repo data files
- add a guildColourStore test to cover both hex string and numeric inputs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce194126888331a1f0d5ba6ffced28