### PR TITLE
Add booster role emblem customization and configuration

### DIFF
--- a/src/commands/brcolor.js
+++ b/src/commands/brcolor.js
@@ -1,0 +1,100 @@
+const { SlashCommandBuilder } = require('discord.js');
+const boosterManager = require('../utils/boosterRoleManager');
+const boosterStore = require('../utils/boosterRoleStore');
+
+function formatHex(hex) {
+  return typeof hex === 'string' ? hex.toUpperCase() : hex;
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('brcolor')
+    .setDescription('Update the colour of your booster custom role')
+    .addStringOption(option =>
+      option
+        .setName('style')
+        .setDescription('Choose a solid colour or gradient')
+        .setRequired(true)
+        .addChoices(
+          { name: 'Solid', value: 'solid' },
+          { name: 'Gradient', value: 'gradient' },
+        )
+    )
+    .addStringOption(option =>
+      option
+        .setName('primary')
+        .setDescription('Primary hex colour (example: #ff8800)')
+        .setRequired(true)
+    )
+    .addStringOption(option =>
+      option
+        .setName('secondary')
+        .setDescription('Secondary hex colour for gradients (example: #00ffaa)')
+        .setRequired(false)
+    ),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ content: 'This command can only be used in a server.', ephemeral: true });
+    }
+
+    const style = interaction.options.getString('style', true);
+    const primary = interaction.options.getString('primary', true);
+    const secondary = interaction.options.getString('secondary');
+
+    if (style === 'gradient' && !secondary) {
+      return interaction.reply({
+        content: 'Please provide two hex colours when selecting the gradient option.',
+        ephemeral: true,
+      });
+    }
+
+    const config = boosterManager.normalizeColorConfig({
+      mode: style,
+      colors: style === 'gradient' ? [primary, secondary] : [primary],
+      secondary,
+    });
+
+    if (!config) {
+      return interaction.reply({
+        content: 'Please provide valid hex colours, such as #ff8800.',
+        ephemeral: true,
+      });
+    }
+
+    const enabled = await boosterStore.isGuildEnabled(interaction.guildId);
+    if (!enabled) {
+      return interaction.reply({
+        content: 'Booster roles are currently disabled on this server.',
+        ephemeral: true,
+      });
+    }
+
+    if (!interaction.deferred && !interaction.replied) {
+      try {
+        await interaction.deferReply({ ephemeral: true });
+      } catch (err) {
+        console.error('Failed to defer /brcolor interaction:', err);
+        return;
+      }
+    }
+
+    try {
+      const { config: appliedConfig, unchanged } = await boosterManager.updateRoleColor(interaction.member, config);
+      let message;
+      if (appliedConfig.mode === 'solid') {
+        const [hex] = appliedConfig.colors;
+        message = `Set your booster role colour to **${formatHex(hex)}**.`;
+      } else {
+        const [start, end] = appliedConfig.colors;
+        message = `Set your booster role gradient to **${formatHex(start)} → ${formatHex(end)}**.`;
+      }
+      if (unchanged) {
+        message += ' Your role already used these colours, so we reapplied them.';
+      }
+      await interaction.editReply({ content: message });
+    } catch (err) {
+      const message = err?.message || 'Failed to update your booster role colour.';
+      await interaction.editReply({ content: `Unable to update booster role colour: ${message}` });
+    }
+  },
+};

--- a/src/commands/brconfig.js
+++ b/src/commands/brconfig.js
@@ -1,0 +1,55 @@
+const { PermissionsBitField, SlashCommandBuilder } = require('discord.js');
+const boosterStore = require('../utils/boosterRoleStore');
+
+function hasManagePermission(interaction) {
+  const perms = interaction.memberPermissions;
+  if (!perms) return false;
+  return (
+    perms.has(PermissionsBitField.Flags.ManageGuild) ||
+    perms.has(PermissionsBitField.Flags.ManageRoles)
+  );
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('brconfig')
+    .setDescription('Enable or disable booster custom roles for this server')
+    .addBooleanOption(option =>
+      option
+        .setName('enabled')
+        .setDescription('Enable booster roles (true) or disable them (false)')
+        .setRequired(true)
+    ),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ content: 'This command can only be used in a server.', ephemeral: true });
+    }
+
+    if (!hasManagePermission(interaction)) {
+      return interaction.reply({
+        content: 'You need the Manage Guild or Manage Roles permission to configure booster roles.',
+        ephemeral: true,
+      });
+    }
+
+    const enabled = interaction.options.getBoolean('enabled', true);
+
+    try {
+      await boosterStore.setGuildEnabled(interaction.guildId, enabled);
+    } catch (err) {
+      console.error(`Failed to update booster role configuration for ${interaction.guildId}:`, err);
+      return interaction.reply({
+        content: 'Something went wrong while saving the booster role configuration. Please try again later.',
+        ephemeral: true,
+      });
+    }
+
+    const status = enabled ? 'enabled' : 'disabled';
+    let message = `Booster roles are now **${status}** for this server.`;
+    if (enabled) {
+      message += ' Use /brsync to ensure existing boosters receive their roles.';
+    }
+
+    return interaction.reply({ content: message, ephemeral: true });
+  },
+};

--- a/src/commands/bremblem.js
+++ b/src/commands/bremblem.js
@@ -1,0 +1,83 @@
+const { SlashCommandBuilder } = require('discord.js');
+const boosterManager = require('../utils/boosterRoleManager');
+const boosterStore = require('../utils/boosterRoleStore');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('bremblem')
+    .setDescription('Update the emblem for your booster custom role')
+    .addAttachmentOption(option =>
+      option
+        .setName('image')
+        .setDescription('PNG or JPEG image under 256 KB to use as your emblem')
+        .setRequired(false)
+    )
+    .addBooleanOption(option =>
+      option
+        .setName('clear')
+        .setDescription('Remove your booster emblem')
+        .setRequired(false)
+    ),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ content: 'This command can only be used in a server.', ephemeral: true });
+    }
+
+    const enabled = await boosterStore.isGuildEnabled(interaction.guildId);
+    if (!enabled) {
+      return interaction.reply({
+        content: 'Booster roles are currently disabled on this server.',
+        ephemeral: true,
+      });
+    }
+
+    const shouldClear = interaction.options.getBoolean('clear') ?? false;
+    const attachment = interaction.options.getAttachment('image');
+
+    if (shouldClear && attachment) {
+      return interaction.reply({
+        content: 'Please choose either an image to upload or enable the clear option, not both.',
+        ephemeral: true,
+      });
+    }
+
+    if (!shouldClear && !attachment) {
+      return interaction.reply({
+        content: 'Please upload an image or enable the clear option to remove your emblem.',
+        ephemeral: true,
+      });
+    }
+
+    if (!interaction.deferred && !interaction.replied) {
+      try {
+        await interaction.deferReply({ ephemeral: true });
+      } catch (err) {
+        console.error('Failed to defer /bremblem interaction:', err);
+        return;
+      }
+    }
+
+    try {
+      const result = await boosterManager.updateRoleEmblem(interaction.member, {
+        attachment,
+        clear: shouldClear,
+      });
+
+      let content;
+      if (result.cleared) {
+        content = result.hadExisting
+          ? 'Cleared your booster role emblem.'
+          : 'Your booster role does not currently have an emblem, but we cleared it just in case.';
+      } else {
+        content = result.hadExisting
+          ? 'Updated your booster role emblem.'
+          : 'Set a booster role emblem for you.';
+      }
+
+      await interaction.editReply({ content });
+    } catch (err) {
+      const message = err?.message || 'Failed to update your booster role emblem.';
+      await interaction.editReply({ content: `Unable to update booster role emblem: ${message}` });
+    }
+  },
+};

--- a/src/commands/brname.js
+++ b/src/commands/brname.js
@@ -1,0 +1,55 @@
+const { SlashCommandBuilder } = require('discord.js');
+const boosterManager = require('../utils/boosterRoleManager');
+const boosterStore = require('../utils/boosterRoleStore');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('brname')
+    .setDescription('Rename your booster custom role')
+    .addStringOption(option =>
+      option
+        .setName('name')
+        .setDescription('The new name for your booster role')
+        .setRequired(true)
+    ),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ content: 'This command can only be used in a server.', ephemeral: true });
+    }
+
+    const requestedName = interaction.options.getString('name', true);
+    const sanitized = boosterManager.sanitizeCustomName(requestedName);
+    if (!sanitized) {
+      return interaction.reply({ content: 'Please provide a valid name to use for your booster role.', ephemeral: true });
+    }
+
+    const enabled = await boosterStore.isGuildEnabled(interaction.guildId);
+    if (!enabled) {
+      return interaction.reply({
+        content: 'Booster roles are currently disabled on this server.',
+        ephemeral: true,
+      });
+    }
+    if (/@everyone|@here/.test(sanitized)) {
+      return interaction.reply({ content: 'You cannot include mass mentions in your booster role name.', ephemeral: true });
+    }
+
+    if (!interaction.deferred && !interaction.replied) {
+      try {
+        await interaction.deferReply({ ephemeral: true });
+      } catch (err) {
+        console.error('Failed to defer /brname interaction:', err);
+        return;
+      }
+    }
+
+    try {
+      const role = await boosterManager.renameRole(interaction.member, sanitized);
+      const content = role ? `Your booster role is now called **${role.name}**.` : 'Updated your booster role.';
+      await interaction.editReply({ content });
+    } catch (err) {
+      const message = err?.message || 'Failed to rename your booster role.';
+      await interaction.editReply({ content: `Unable to rename booster role: ${message}` });
+    }
+  },
+};

--- a/src/commands/brsync.js
+++ b/src/commands/brsync.js
@@ -1,0 +1,77 @@
+const { PermissionsBitField, SlashCommandBuilder } = require('discord.js');
+const boosterManager = require('../utils/boosterRoleManager');
+const boosterStore = require('../utils/boosterRoleStore');
+
+function canManage(interaction) {
+  const perms = interaction.memberPermissions;
+  if (!perms) return false;
+  return (
+    perms.has(PermissionsBitField.Flags.ManageRoles) ||
+    perms.has(PermissionsBitField.Flags.ManageGuild)
+  );
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('brsync')
+    .setDescription('Ensure current boosters have their custom roles assigned'),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ content: 'This command can only be used in a server.', ephemeral: true });
+    }
+
+    if (!canManage(interaction)) {
+      return interaction.reply({
+        content: 'You need the Manage Roles or Manage Guild permission to sync booster roles.',
+        ephemeral: true,
+      });
+    }
+
+    const enabled = await boosterStore.isGuildEnabled(interaction.guildId);
+    if (!enabled) {
+      return interaction.reply({
+        content: 'Booster roles are currently disabled on this server.',
+        ephemeral: true,
+      });
+    }
+
+    if (!interaction.deferred && !interaction.replied) {
+      try {
+        await interaction.deferReply({ ephemeral: true });
+      } catch (err) {
+        console.error('Failed to defer /brsync interaction:', err);
+        return;
+      }
+    }
+
+    let summary;
+    try {
+      summary = await boosterManager.syncBoosters(interaction.guild);
+    } catch (err) {
+      const message = err?.message || 'Failed to sync booster roles.';
+      await interaction.editReply({ content: `Unable to sync booster roles: ${message}` });
+      return;
+    }
+
+    const { totalBoosters, ensured, created, failed } = summary;
+    let content =
+      `Checked **${totalBoosters}** boosting member${totalBoosters === 1 ? '' : 's'} ` +
+      `and confirmed custom roles for **${ensured}**.`;
+    if (created > 0) {
+      content += ` Created **${created}** new role${created === 1 ? '' : 's'}.`;
+    }
+    if (failed.length > 0) {
+      const details = failed
+        .slice(0, 5)
+        .map(entry => `• <@${entry.userId}> (${entry.message})`)
+        .join('\n');
+      content += `\n\nEncountered **${failed.length}** issue${failed.length === 1 ? '' : 's'}:`;
+      content += `\n${details}`;
+      if (failed.length > 5) {
+        content += '\n…and more. Check the logs for full details.';
+      }
+    }
+
+    await interaction.editReply({ content });
+  },
+};

--- a/src/events/guildMemberUpdate.boosterRoles.js
+++ b/src/events/guildMemberUpdate.boosterRoles.js
@@ -1,0 +1,68 @@
+const { Events, PermissionsBitField } = require('discord.js');
+const boosterStore = require('../utils/boosterRoleStore');
+const boosterManager = require('../utils/boosterRoleManager');
+
+async function getMe(guild) {
+  if (!guild) return null;
+  const me = guild.members.me;
+  if (me) return me;
+  try { return await guild.members.fetchMe(); } catch (_) { return null; }
+}
+
+module.exports = {
+  name: Events.GuildMemberUpdate,
+  async execute(oldMember, newMember) {
+    try {
+      if (!newMember?.guild) return;
+      const guild = newMember.guild;
+
+      const enabled = await boosterStore.isGuildEnabled(guild.id);
+      if (!enabled) return;
+
+      const hadBoost = Boolean(oldMember?.premiumSinceTimestamp || oldMember?.premiumSince);
+      const hasBoost = Boolean(newMember?.premiumSinceTimestamp || newMember?.premiumSince);
+
+      if (hasBoost && !hadBoost) {
+        try {
+          await boosterManager.ensureRole(newMember, { createIfMissing: true });
+        } catch (err) {
+          console.error(`Failed to ensure booster role for ${newMember.id} in ${guild.id}:`, err);
+        }
+        return;
+      }
+
+      if (!hasBoost && hadBoost) {
+        const roleId = await boosterStore.getRoleId(guild.id, newMember.id);
+        if (!roleId) return;
+        let role = null;
+        try { role = await guild.roles.fetch(roleId); } catch (_) { role = null; }
+        if (!role) {
+          await boosterStore.deleteRole(guild.id, newMember.id);
+          return;
+        }
+
+        const me = await getMe(guild);
+        const canManage = me?.permissions?.has(PermissionsBitField.Flags.ManageRoles) && me.roles?.highest?.comparePositionTo(role) > 0;
+        if (!canManage) return;
+
+        try {
+          if (newMember.roles?.cache?.has(role.id)) {
+            await newMember.roles.remove(role, 'Booster removed their boost');
+          }
+        } catch (err) {
+          console.warn(`Failed to remove booster role from ${newMember.id}:`, err);
+        }
+
+        try {
+          await role.delete('Booster removed their boost');
+        } catch (err) {
+          console.warn(`Failed to delete booster role ${role.id} in ${guild.id}:`, err);
+        }
+
+        await boosterStore.deleteRole(guild.id, newMember.id);
+      }
+    } catch (err) {
+      console.error('Failed handling booster role update:', err);
+    }
+  },
+};

--- a/src/utils/boosterRoleManager.js
+++ b/src/utils/boosterRoleManager.js
@@ -1,0 +1,642 @@
+const { PermissionsBitField } = require('discord.js');
+const path = require('node:path');
+const fs = require('node:fs/promises');
+const zlib = require('node:zlib');
+const boosterStore = require('./boosterRoleStore');
+const { resolveDataPath, ensureDir } = require('./dataDir');
+// node-fetch v3 is ESM-only; dynamic import for CommonJS
+const fetch = (...args) => import('node-fetch').then(({ default: fetchFn }) => fetchFn(...args));
+
+const ROLE_SUFFIX = "'s Custom Role";
+const GRADIENT_ICON_SIZE = 128;
+const ROLE_ICON_FEATURE = 'ROLE_ICONS';
+const EMBLEM_DIR = 'booster-emblems';
+const MAX_EMBLEM_SIZE = 256 * 1024; // 256 KB Discord role icon limit
+const EMBLEM_CONTENT_TYPES = new Map([
+  ['image/png', '.png'],
+  ['image/jpeg', '.jpg'],
+  ['image/jpg', '.jpg'],
+]);
+const CRC_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n += 1) {
+    let c = n;
+    for (let k = 0; k < 8; k += 1) {
+      c = (c & 1) ? (0xEDB88320 ^ (c >>> 1)) : (c >>> 1);
+    }
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+function normalizeHexColor(input) {
+  if (!input) return null;
+  const match = String(input).trim().match(/^#?([0-9a-fA-F]{6})$/);
+  if (!match) return null;
+  return `#${match[1].toUpperCase()}`;
+}
+
+function hexToRgb(hex) {
+  const normalized = normalizeHexColor(hex);
+  if (!normalized) return null;
+  return {
+    r: parseInt(normalized.slice(1, 3), 16),
+    g: parseInt(normalized.slice(3, 5), 16),
+    b: parseInt(normalized.slice(5, 7), 16),
+  };
+}
+
+function colorsEqual(a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string') return false;
+  return a.trim().toLowerCase() === b.trim().toLowerCase();
+}
+
+function normalizeColorConfig(config) {
+  if (!config || typeof config !== 'object') return null;
+  const mode = config.mode === 'gradient' ? 'gradient' : 'solid';
+  const rawColors = Array.isArray(config.colors) ? config.colors : [];
+
+  if (mode === 'solid') {
+    const candidate = rawColors[0] ?? config.color ?? config.primary;
+    const hex = normalizeHexColor(candidate);
+    if (!hex) return null;
+    return { mode: 'solid', colors: [hex] };
+  }
+
+  const candidates = [];
+  if (rawColors.length > 0) candidates.push(...rawColors.slice(0, 2));
+  if (candidates.length < 2) {
+    if (typeof config.start !== 'undefined') candidates.push(config.start);
+    if (typeof config.end !== 'undefined') candidates.push(config.end);
+    if (typeof config.secondary !== 'undefined') candidates.push(config.secondary);
+  }
+  const sanitized = candidates.map(normalizeHexColor).filter(Boolean);
+  if (sanitized.length < 2) return null;
+  return { mode: 'gradient', colors: sanitized.slice(0, 2) };
+}
+
+function colorConfigEquals(a, b) {
+  if (!a || !b) return false;
+  if (a.mode !== b.mode) return false;
+  const colorsA = Array.isArray(a.colors) ? a.colors : [];
+  const colorsB = Array.isArray(b.colors) ? b.colors : [];
+  if (colorsA.length !== colorsB.length) return false;
+  for (let i = 0; i < colorsA.length; i += 1) {
+    if (!colorsEqual(colorsA[i], colorsB[i])) return false;
+  }
+  return true;
+}
+
+function crc32(buffer) {
+  let crc = 0xFFFFFFFF;
+  for (let i = 0; i < buffer.length; i += 1) {
+    const byte = buffer[i];
+    crc = CRC_TABLE[(crc ^ byte) & 0xFF] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xFFFFFFFF) >>> 0;
+}
+
+function createChunk(type, data) {
+  const typeBuffer = Buffer.from(type, 'ascii');
+  const lengthBuffer = Buffer.alloc(4);
+  lengthBuffer.writeUInt32BE(data.length, 0);
+  const crcBuffer = Buffer.alloc(4);
+  const crc = crc32(Buffer.concat([typeBuffer, data]));
+  crcBuffer.writeUInt32BE(crc >>> 0, 0);
+  return Buffer.concat([lengthBuffer, typeBuffer, data, crcBuffer]);
+}
+
+function createGradientIconBuffer(startHex, endHex) {
+  const start = hexToRgb(startHex);
+  const end = hexToRgb(endHex);
+  if (!start || !end) throw new Error('Invalid gradient colours provided.');
+
+  const width = GRADIENT_ICON_SIZE;
+  const height = GRADIENT_ICON_SIZE;
+  const rowLength = width * 4 + 1;
+  const raw = Buffer.alloc(rowLength * height);
+
+  for (let y = 0; y < height; y += 1) {
+    const ratio = height === 1 ? 0 : y / (height - 1);
+    const r = Math.round(start.r + (end.r - start.r) * ratio);
+    const g = Math.round(start.g + (end.g - start.g) * ratio);
+    const b = Math.round(start.b + (end.b - start.b) * ratio);
+    const rowOffset = y * rowLength;
+    raw[rowOffset] = 0; // filter type none
+    for (let x = 0; x < width; x += 1) {
+      const idx = rowOffset + 1 + x * 4;
+      raw[idx] = r;
+      raw[idx + 1] = g;
+      raw[idx + 2] = b;
+      raw[idx + 3] = 255;
+    }
+  }
+
+  const compressed = zlib.deflateSync(raw, { level: 9 });
+
+  const signature = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr.writeUInt8(8, 8); // bit depth
+  ihdr.writeUInt8(6, 9); // colour type RGBA
+  ihdr.writeUInt8(0, 10); // compression
+  ihdr.writeUInt8(0, 11); // filter
+  ihdr.writeUInt8(0, 12); // interlace
+
+  const ihdrChunk = createChunk('IHDR', ihdr);
+  const idatChunk = createChunk('IDAT', compressed);
+  const iendChunk = createChunk('IEND', Buffer.alloc(0));
+
+  return Buffer.concat([signature, ihdrChunk, idatChunk, iendChunk]);
+}
+
+function sanitizeNameFragment(input) {
+  if (!input) return 'Booster';
+  const trimmed = String(input).replace(/[\r\n]/g, ' ').trim();
+  return trimmed || 'Booster';
+}
+
+function buildDefaultRoleName(member) {
+  const base = sanitizeNameFragment(member?.displayName || member?.nickname || member?.user?.username || member?.user?.tag || 'Booster');
+  const suffix = ROLE_SUFFIX;
+  const maxBaseLength = Math.max(1, 100 - suffix.length);
+  let safeBase = base;
+  if (safeBase.length > maxBaseLength) {
+    safeBase = safeBase.slice(0, maxBaseLength).trim();
+    if (!safeBase) safeBase = base.slice(0, maxBaseLength);
+  }
+  if (!safeBase) safeBase = 'Booster';
+  let name = `${safeBase}${suffix}`;
+  if (name.length > 100) name = name.slice(0, 100);
+  return name;
+}
+
+function sanitizeCustomName(name) {
+  const trimmed = String(name ?? '').replace(/[\r\n]/g, ' ').trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, 100);
+}
+
+async function fetchMe(guild) {
+  if (!guild) return null;
+  const existing = guild.members.me;
+  if (existing) return existing;
+  try { return await guild.members.fetchMe(); } catch (err) { return null; }
+}
+
+function getEmblemExtension(attachment) {
+  if (!attachment) return null;
+  const contentType = (attachment.contentType || '').toLowerCase();
+  if (EMBLEM_CONTENT_TYPES.has(contentType)) {
+    return { extension: EMBLEM_CONTENT_TYPES.get(contentType), contentType };
+  }
+  const name = (attachment.name || '').toLowerCase();
+  const match = name.match(/\.(png|jpe?g)$/);
+  if (!match) return null;
+  const ext = match[0];
+  const type = ext === '.png' ? 'image/png' : 'image/jpeg';
+  return { extension: ext, contentType: type };
+}
+
+async function saveEmblemAsset(guildId, userId, buffer, { extension, contentType, name }) {
+  const relativeDir = path.join(EMBLEM_DIR, guildId);
+  const fileName = `${userId}${extension}`;
+  const relativePath = path.join(relativeDir, fileName);
+  const absolutePath = resolveDataPath(relativePath);
+  await ensureDir(path.dirname(absolutePath));
+  await fs.writeFile(absolutePath, buffer);
+  return {
+    file: relativePath,
+    contentType,
+    name: name || null,
+    size: buffer.length,
+    uploadedAt: new Date().toISOString(),
+  };
+}
+
+async function loadEmblemBuffer(emblem) {
+  if (!emblem || typeof emblem !== 'object' || !emblem.file) return null;
+  try {
+    return await fs.readFile(resolveDataPath(emblem.file));
+  } catch (err) {
+    if (err?.code !== 'ENOENT') throw err;
+    return null;
+  }
+}
+
+async function applyRoleEmblem(role, emblem, targetMember, { reason } = {}) {
+  if (!role || !emblem) return { iconUpdated: false };
+  const buffer = await loadEmblemBuffer(emblem);
+  if (!buffer) {
+    throw new Error('The stored booster emblem could not be found.');
+  }
+  const actor = targetMember?.user?.tag || targetMember?.id || 'booster';
+  const reasonText = reason || `Updated booster role emblem for ${actor}`;
+  try {
+    await role.setIcon(buffer, reasonText);
+  } catch (err) {
+    throw new Error(`Failed to set booster role emblem: ${err.message || err}`);
+  }
+  return { iconUpdated: true };
+}
+
+async function ensureManageable(me, rolePosition) {
+  if (!me) throw new Error('Bot member unavailable');
+  if (!me.permissions.has(PermissionsBitField.Flags.ManageRoles)) {
+    throw new Error('Missing Manage Roles');
+  }
+  if (typeof rolePosition === 'number' && me.roles.highest && me.roles.highest.position <= rolePosition) {
+    throw new Error('Role hierarchy prevents managing the booster role');
+  }
+}
+
+async function applyRoleColor(role, colorConfig, targetMember, { reason } = {}) {
+  if (!role || !colorConfig) return { colorUpdated: false, iconUpdated: false };
+
+  const actor = targetMember?.user?.tag || targetMember?.id || 'booster';
+  const reasonText = reason || `Updated booster role appearance for ${actor}`;
+
+  if (colorConfig.mode === 'solid') {
+    const [hex] = colorConfig.colors || [];
+    if (!hex) throw new Error('Missing colour value for solid mode.');
+    let colorUpdated = false;
+    if (!colorsEqual(role.hexColor, hex)) {
+      try {
+        await role.setColor(hex, reasonText);
+        colorUpdated = true;
+      } catch (err) {
+        throw new Error(`Failed to update booster role colour: ${err.message || err}`);
+      }
+    }
+    let iconUpdated = false;
+    if (role.icon) {
+      try {
+        await role.setIcon(null, reasonText);
+        iconUpdated = true;
+      } catch (err) {
+        throw new Error(`Failed to clear booster role icon: ${err.message || err}`);
+      }
+    }
+    return { colorUpdated, iconUpdated, mode: 'solid' };
+  }
+
+  if (colorConfig.mode === 'gradient') {
+    const [startHex, endHex] = colorConfig.colors || [];
+    if (!startHex || !endHex) throw new Error('Please supply two colours for the gradient.');
+    const guild = role.guild;
+    const features = Array.isArray(guild?.features) ? guild.features : [];
+    if (!features.includes(ROLE_ICON_FEATURE)) {
+      throw new Error('This server does not support role icons, so gradient colours are unavailable.');
+    }
+
+    let buffer;
+    try {
+      buffer = createGradientIconBuffer(startHex, endHex);
+    } catch (err) {
+      throw new Error(err?.message || 'Failed to generate gradient icon.');
+    }
+
+    let colorUpdated = false;
+    if (!colorsEqual(role.hexColor, startHex)) {
+      try {
+        await role.setColor(startHex, reasonText);
+        colorUpdated = true;
+      } catch (err) {
+        throw new Error(`Failed to update booster role colour: ${err.message || err}`);
+      }
+    }
+
+    try {
+      await role.setIcon(buffer, reasonText);
+    } catch (err) {
+      throw new Error(`Failed to set booster role gradient icon: ${err.message || err}`);
+    }
+
+    return { colorUpdated, iconUpdated: true, mode: 'gradient' };
+  }
+
+  throw new Error('Unsupported colour mode requested.');
+}
+
+async function ensureRole(member, { createIfMissing = true, applyStoredColor = true } = {}) {
+  if (!member?.guild) throw new Error('Member is not in a guild');
+  const guild = member.guild;
+  const userId = member.id;
+  const guildId = guild.id;
+
+  let targetMember = member;
+  if (!targetMember.roles || !targetMember.roles.cache) {
+    try {
+      targetMember = await guild.members.fetch(userId);
+    } catch (err) {
+      throw new Error('Failed to fetch member data');
+    }
+  }
+
+  let roleId = await boosterStore.getRoleId(guildId, userId);
+  let role = null;
+  if (roleId) {
+    try { role = await guild.roles.fetch(roleId); } catch (_) { role = null; }
+    if (!role) {
+      await boosterStore.deleteRole(guildId, userId);
+      roleId = null;
+    }
+  }
+
+  const me = await fetchMe(guild);
+  await ensureManageable(me, role?.position);
+
+  if (!role && createIfMissing) {
+    const name = buildDefaultRoleName(targetMember);
+    role = await guild.roles.create({
+      name,
+      reason: `Custom booster role created for ${targetMember.user?.tag || targetMember.id}`,
+      mentionable: false,
+    });
+    await boosterStore.setRoleId(guildId, userId, role.id);
+  }
+
+  if (role) {
+    if (me.roles.highest && me.roles.highest.comparePositionTo(role) <= 0) {
+      throw new Error('Role hierarchy prevents managing the booster role');
+    }
+    const hasRole = targetMember.roles.cache.has(role.id);
+    if (!hasRole) {
+      try {
+        await targetMember.roles.add(role, 'Assigning booster custom role');
+      } catch (err) {
+        throw new Error(`Failed to assign booster role: ${err.message || err}`);
+      }
+    }
+  }
+
+  if (role && applyStoredColor) {
+    let storedConfig = null;
+    try {
+      storedConfig = await boosterStore.getColorConfig(guildId, userId);
+    } catch (err) {
+      console.warn(`Failed to read stored booster colour for ${userId} in ${guildId}:`, err);
+    }
+    if (storedConfig) {
+      try {
+        await applyRoleColor(role, storedConfig, targetMember, {
+          reason: `Reapplying saved booster colour for ${targetMember.user?.tag || targetMember.id}`,
+        });
+      } catch (err) {
+        console.warn(`Failed to reapply booster colour for ${userId} in ${guildId}:`, err);
+      }
+    }
+
+    let storedEmblem = null;
+    try {
+      storedEmblem = await boosterStore.getEmblem(guildId, userId);
+    } catch (err) {
+      console.warn(`Failed to read stored booster emblem for ${userId} in ${guildId}:`, err);
+    }
+    if (storedEmblem) {
+      try {
+        await applyRoleEmblem(role, storedEmblem, targetMember, {
+          reason: `Reapplying saved booster emblem for ${targetMember.user?.tag || targetMember.id}`,
+        });
+      } catch (err) {
+        console.warn(`Failed to reapply booster emblem for ${userId} in ${guildId}:`, err);
+      }
+    }
+  }
+
+  return { role, created: !!(!roleId && role), member: targetMember };
+}
+
+async function syncBoosters(guild) {
+  if (!guild) throw new Error('Guild not available');
+
+  const me = await fetchMe(guild);
+  if (!me) {
+    throw new Error('Bot member unavailable');
+  }
+  if (!me.permissions?.has(PermissionsBitField.Flags.ManageRoles)) {
+    throw new Error('Missing Manage Roles');
+  }
+
+  let members;
+  try {
+    members = await guild.members.fetch();
+  } catch (err) {
+    throw new Error(`Failed to fetch guild members: ${err?.message || err}`);
+  }
+
+  const boosters = members.filter(member =>
+    Boolean(member?.premiumSinceTimestamp || member?.premiumSince)
+  );
+
+  const summary = {
+    totalBoosters: boosters.size,
+    ensured: 0,
+    created: 0,
+    failed: [],
+  };
+
+  for (const booster of boosters.values()) {
+    try {
+      const result = await ensureRole(booster, { createIfMissing: true });
+      if (result?.role) {
+        summary.ensured += 1;
+        if (result.created) summary.created += 1;
+      }
+    } catch (err) {
+      summary.failed.push({
+        userId: booster.id,
+        message: err?.message || String(err),
+      });
+    }
+  }
+
+  return summary;
+}
+
+module.exports = {
+  ROLE_SUFFIX,
+  buildDefaultRoleName,
+  sanitizeCustomName,
+  ensureRole,
+  normalizeColorConfig,
+  syncBoosters,
+  async renameRole(member, desiredName) {
+    const name = sanitizeCustomName(desiredName);
+    if (!name) throw new Error('Please provide a non-empty name.');
+
+    const { role, member: targetMember } = await ensureRole(member, { createIfMissing: true });
+    if (!role) throw new Error('You do not have a booster role yet.');
+
+    const guild = targetMember.guild;
+    const me = await fetchMe(guild);
+    await ensureManageable(me, role.position);
+
+    if (role.name === name) {
+      return role;
+    }
+
+    try {
+      const updated = await role.setName(name, `Renamed by ${targetMember.user?.tag || targetMember.id}`);
+      return updated;
+    } catch (err) {
+      throw new Error(`Failed to rename booster role: ${err.message || err}`);
+    }
+  },
+  async updateRoleColor(member, colorInput) {
+    const normalized = normalizeColorConfig(colorInput);
+    if (!normalized) {
+      throw new Error('Please provide valid hex colours (example: #ff8800).');
+    }
+
+    const { role, member: targetMember } = await ensureRole(member, {
+      createIfMissing: true,
+      applyStoredColor: false,
+    });
+    if (!role) throw new Error('You do not have a booster role yet.');
+
+    const guild = targetMember.guild;
+    const me = await fetchMe(guild);
+    await ensureManageable(me, role.position);
+
+    let existingConfig = null;
+    try {
+      existingConfig = await boosterStore.getColorConfig(guild.id, targetMember.id);
+    } catch (err) {
+      console.warn(`Failed to read existing booster colour for ${targetMember.id} in ${guild.id}:`, err);
+    }
+
+    let existingEmblem = null;
+    try {
+      existingEmblem = await boosterStore.getEmblem(guild.id, targetMember.id);
+    } catch (err) {
+      console.warn(`Failed to read existing booster emblem for ${targetMember.id} in ${guild.id}:`, err);
+    }
+
+    let result;
+    try {
+      result = await applyRoleColor(role, normalized, targetMember, {
+        reason: `Booster role colour updated by ${targetMember.user?.tag || targetMember.id}`,
+      });
+    } catch (err) {
+      throw err instanceof Error ? err : new Error(err);
+    }
+
+    await boosterStore.setColorConfig(guild.id, targetMember.id, normalized);
+
+    if (normalized.mode === 'gradient') {
+      await boosterStore.setEmblem(guild.id, targetMember.id, null);
+    } else if (existingEmblem) {
+      try {
+        await applyRoleEmblem(role, existingEmblem, targetMember, {
+          reason: `Reapplying booster emblem after colour update for ${targetMember.user?.tag || targetMember.id}`,
+        });
+      } catch (err) {
+        console.warn(`Failed to restore booster emblem for ${targetMember.id} in ${guild.id}:`, err);
+      }
+    }
+
+    return { role, config: normalized, result, unchanged: colorConfigEquals(existingConfig, normalized) };
+  },
+
+  async updateRoleEmblem(member, { attachment, clear = false } = {}) {
+    if (!member?.guild) throw new Error('Member is not in a guild');
+
+    const { role, member: targetMember } = await ensureRole(member, {
+      createIfMissing: true,
+      applyStoredColor: false,
+    });
+    if (!role) throw new Error('You do not have a booster role yet.');
+
+    const guild = targetMember.guild;
+    const me = await fetchMe(guild);
+    await ensureManageable(me, role.position);
+
+    const guildFeatures = Array.isArray(guild?.features) ? guild.features : [];
+    if (!guildFeatures.includes(ROLE_ICON_FEATURE)) {
+      throw new Error('This server does not support role icons, so booster emblems are unavailable.');
+    }
+
+    let existingEmblem = null;
+    try {
+      existingEmblem = await boosterStore.getEmblem(guild.id, targetMember.id);
+    } catch (err) {
+      console.warn(`Failed to read existing booster emblem for ${targetMember.id} in ${guild.id}:`, err);
+    }
+
+    const actor = targetMember.user?.tag || targetMember.id;
+
+    if (clear) {
+      try {
+        await role.setIcon(null, `Booster emblem cleared by ${actor}`);
+      } catch (err) {
+        throw new Error(`Failed to clear booster role emblem: ${err.message || err}`);
+      }
+      await boosterStore.setEmblem(guild.id, targetMember.id, null);
+      return { role, emblem: null, cleared: true, hadExisting: !!existingEmblem };
+    }
+
+    if (!attachment) {
+      throw new Error('Please attach a PNG or JPEG image to use as your booster emblem.');
+    }
+
+    if (attachment.size && attachment.size > MAX_EMBLEM_SIZE) {
+      throw new Error('Please choose an image that is 256 KB or smaller.');
+    }
+
+    const extInfo = getEmblemExtension(attachment);
+    if (!extInfo) {
+      throw new Error('Please provide a PNG or JPEG image to use as your booster emblem.');
+    }
+
+    let response;
+    try {
+      response = await fetch(attachment.url);
+    } catch (err) {
+      throw new Error(`Failed to download the provided emblem: ${err.message || err}`);
+    }
+    if (!response?.ok) {
+      throw new Error(`Failed to download the provided emblem (status ${response?.status || 'unknown'}).`);
+    }
+
+    let buffer;
+    try {
+      const arrayBuffer = await response.arrayBuffer();
+      buffer = Buffer.from(arrayBuffer);
+    } catch (err) {
+      throw new Error('The provided emblem image could not be processed.');
+    }
+
+    if (!buffer?.length) {
+      throw new Error('The provided emblem image is empty.');
+    }
+
+    if (buffer.length > MAX_EMBLEM_SIZE) {
+      throw new Error('Please choose an image that is 256 KB or smaller.');
+    }
+
+    const metadata = await saveEmblemAsset(guild.id, targetMember.id, buffer, {
+      extension: extInfo.extension,
+      contentType: extInfo.contentType,
+      name: attachment.name || null,
+    });
+
+    try {
+      await role.setIcon(buffer, `Booster emblem updated by ${actor}`);
+    } catch (err) {
+      try {
+        await fs.unlink(resolveDataPath(metadata.file));
+      } catch (cleanupErr) {
+        if (cleanupErr?.code !== 'ENOENT') {
+          console.warn(`Failed to clean up booster emblem asset ${metadata.file} after error:`, cleanupErr);
+        }
+      }
+      throw new Error(`Failed to update booster role emblem: ${err.message || err}`);
+    }
+
+    await boosterStore.setEmblem(guild.id, targetMember.id, metadata);
+
+    return { role, emblem: metadata, cleared: false, hadExisting: !!existingEmblem };
+  },
+};

--- a/src/utils/boosterRoleStore.js
+++ b/src/utils/boosterRoleStore.js
@@ -1,0 +1,243 @@
+const fs = require('fs/promises');
+const { ensureFile, writeJson, resolveDataPath } = require('./dataDir');
+
+const STORE_FILE = 'boosterRoles.json';
+
+let cache = null;
+let saveTimer = null;
+
+async function deleteEmblemAsset(emblem) {
+  if (!emblem || typeof emblem !== 'object') return;
+  const file = emblem.file || emblem.path;
+  if (!file) return;
+  try {
+    await fs.unlink(resolveDataPath(file));
+  } catch (err) {
+    if (!err || err.code === 'ENOENT') return;
+    console.warn(`Failed to remove booster emblem asset ${file}:`, err);
+  }
+}
+
+async function ensureStore() {
+  try {
+    await ensureFile(STORE_FILE, { guilds: {} });
+  } catch (err) {
+    console.error('Failed to ensure booster role store file:', err);
+  }
+}
+
+async function load() {
+  if (cache) return cache;
+  await ensureStore();
+  try {
+    const raw = await fs.readFile(resolveDataPath(STORE_FILE), 'utf8');
+    const parsed = raw ? JSON.parse(raw) : { guilds: {} };
+    if (!parsed.guilds || typeof parsed.guilds !== 'object') parsed.guilds = {};
+    cache = parsed;
+  } catch (err) {
+    console.error('Failed to load booster role store:', err);
+    cache = { guilds: {} };
+  }
+  return cache;
+}
+
+function scheduleSave() {
+  if (saveTimer) return;
+  saveTimer = setTimeout(async () => {
+    saveTimer = null;
+    if (!cache) return;
+    try {
+      if (!cache.guilds || typeof cache.guilds !== 'object') cache.guilds = {};
+      await writeJson(STORE_FILE, cache);
+    } catch (err) {
+      console.error('Failed to persist booster role store:', err);
+    }
+  }, 100);
+}
+
+function getGuild(data, guildId) {
+  if (!data.guilds[guildId]) data.guilds[guildId] = { boosters: {}, config: {} };
+  const entry = data.guilds[guildId];
+  if (!entry.boosters || typeof entry.boosters !== 'object') entry.boosters = {};
+  if (!entry.config || typeof entry.config !== 'object') entry.config = {};
+  return entry;
+}
+
+function scheduleCleanup(guild, userId) {
+  const entry = guild.boosters[userId];
+  if (!entry) return;
+  if (entry.roleId || entry.color || entry.emblem) return;
+  delete guild.boosters[userId];
+}
+
+function normalizeEntry(guild, userId) {
+  const raw = guild.boosters[userId];
+  if (!raw) return null;
+  if (typeof raw === 'string') {
+    const entry = { roleId: raw };
+    guild.boosters[userId] = entry;
+    scheduleSave();
+    return entry;
+  }
+  if (typeof raw === 'object' && raw !== null) {
+    if (raw.roleId && typeof raw.roleId !== 'string') {
+      raw.roleId = String(raw.roleId);
+    }
+    return raw;
+  }
+  delete guild.boosters[userId];
+  scheduleSave();
+  return null;
+}
+
+function ensureEntry(guild, userId) {
+  const existing = normalizeEntry(guild, userId);
+  if (existing) return existing;
+  const created = { roleId: null };
+  guild.boosters[userId] = created;
+  return created;
+}
+
+module.exports = {
+  async getRoleId(guildId, userId) {
+    const data = await load();
+    const g = getGuild(data, guildId);
+    const entry = normalizeEntry(g, userId);
+    return entry?.roleId || null;
+  },
+
+  async setRoleId(guildId, userId, roleId) {
+    const data = await load();
+    const g = getGuild(data, guildId);
+    if (roleId) {
+      const entry = ensureEntry(g, userId);
+      entry.roleId = roleId;
+    } else if (g.boosters[userId]) {
+      const entry = normalizeEntry(g, userId);
+      if (entry) entry.roleId = null;
+      scheduleCleanup(g, userId);
+    }
+    scheduleSave();
+  },
+
+  async deleteRole(guildId, userId) {
+    const data = await load();
+    const g = getGuild(data, guildId);
+    if (g.boosters[userId]) {
+      const entry = normalizeEntry(g, userId);
+      if (entry?.emblem) {
+        await deleteEmblemAsset(entry.emblem);
+      }
+      delete g.boosters[userId];
+      scheduleSave();
+    }
+  },
+
+  async getColorConfig(guildId, userId) {
+    const data = await load();
+    const g = getGuild(data, guildId);
+    const entry = normalizeEntry(g, userId);
+    return entry?.color || null;
+  },
+
+  async setColorConfig(guildId, userId, colorConfig) {
+    const data = await load();
+    const g = getGuild(data, guildId);
+    if (!colorConfig) {
+      const entry = normalizeEntry(g, userId);
+      if (entry && entry.color) {
+        delete entry.color;
+        scheduleCleanup(g, userId);
+        scheduleSave();
+      }
+      return;
+    }
+    const entry = ensureEntry(g, userId);
+    entry.color = colorConfig;
+    scheduleSave();
+  },
+
+  async getEmblem(guildId, userId) {
+    const data = await load();
+    const g = getGuild(data, guildId);
+    const entry = normalizeEntry(g, userId);
+    return entry?.emblem || null;
+  },
+
+  async setEmblem(guildId, userId, emblem) {
+    const data = await load();
+    const g = getGuild(data, guildId);
+    if (!emblem) {
+      const entry = normalizeEntry(g, userId);
+      if (entry && entry.emblem) {
+        await deleteEmblemAsset(entry.emblem);
+        delete entry.emblem;
+        scheduleCleanup(g, userId);
+        scheduleSave();
+      }
+      return;
+    }
+    const entry = ensureEntry(g, userId);
+    if (entry.emblem && entry.emblem.file && entry.emblem.file !== emblem.file) {
+      await deleteEmblemAsset(entry.emblem);
+    }
+    entry.emblem = emblem;
+    scheduleSave();
+  },
+
+  async removeByRoleId(guildId, roleId) {
+    if (!roleId) return;
+    const data = await load();
+    const g = getGuild(data, guildId);
+    let changed = false;
+    for (const [uid, raw] of Object.entries(g.boosters)) {
+      const entry = normalizeEntry(g, uid);
+      if (entry?.roleId === roleId) {
+        if (entry.emblem) {
+          await deleteEmblemAsset(entry.emblem);
+        }
+        delete g.boosters[uid];
+        changed = true;
+      }
+    }
+    if (changed) scheduleSave();
+  },
+
+  async listBoosters(guildId) {
+    const data = await load();
+    const g = getGuild(data, guildId);
+    return Object.entries(g.boosters)
+      .map(([userId, raw]) => {
+        const entry = normalizeEntry(g, userId);
+        if (!entry?.roleId) return null;
+        return {
+          userId,
+          roleId: entry.roleId,
+          color: entry.color || null,
+          emblem: entry.emblem || null,
+        };
+      })
+      .filter(Boolean);
+  },
+
+  async getGuildConfig(guildId) {
+    const data = await load();
+    const g = getGuild(data, guildId);
+    const enabled = typeof g.config.enabled === 'boolean' ? g.config.enabled : true;
+    return { enabled };
+  },
+
+  async isGuildEnabled(guildId) {
+    const data = await load();
+    const g = getGuild(data, guildId);
+    const enabled = typeof g.config.enabled === 'boolean' ? g.config.enabled : true;
+    return Boolean(enabled);
+  },
+
+  async setGuildEnabled(guildId, enabled) {
+    const data = await load();
+    const g = getGuild(data, guildId);
+    g.config.enabled = Boolean(enabled);
+    scheduleSave();
+  },
+};

--- a/tests/boosterRoleStore.test.js
+++ b/tests/boosterRoleStore.test.js
@@ -1,0 +1,138 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dusscord-booster-store-'));
+process.env.DUSSCORD_DATA_DIR = tempDir;
+const dataFile = path.join(tempDir, 'boosterRoles.json');
+
+const modulePath = require.resolve('../src/utils/boosterRoleStore');
+
+async function resetStoreFile(initialData) {
+  const payload = initialData ?? { guilds: {} };
+  await fs.promises.writeFile(dataFile, JSON.stringify(payload, null, 2), 'utf8');
+}
+
+function loadStore() {
+  delete require.cache[modulePath];
+  return require(modulePath);
+}
+
+test('getRoleId converts legacy string entries and preserves colour data', async () => {
+  await resetStoreFile({
+    guilds: {
+      legacy: {
+        boosters: {
+          'user-a': 'role-123',
+        },
+      },
+    },
+  });
+
+  const store = loadStore();
+  const roleId = await store.getRoleId('legacy', 'user-a');
+  assert.strictEqual(roleId, 'role-123');
+
+  const solid = { mode: 'solid', colors: ['#FFA500'] };
+  await store.setColorConfig('legacy', 'user-a', solid);
+  assert.deepStrictEqual(await store.getColorConfig('legacy', 'user-a'), solid);
+
+  assert.strictEqual(await store.getEmblem('legacy', 'user-a'), null);
+
+  const boosters = await store.listBoosters('legacy');
+  assert.deepStrictEqual(boosters, [
+    { userId: 'user-a', roleId: 'role-123', color: solid, emblem: null },
+  ]);
+});
+
+test('setRoleId and setColorConfig clear entries when data is removed', async () => {
+  await resetStoreFile();
+  const store = loadStore();
+
+  const gradient = { mode: 'gradient', colors: ['#112233', '#445566'] };
+  await store.setRoleId('guild-1', 'user-1', 'role-abc');
+  await store.setColorConfig('guild-1', 'user-1', gradient);
+
+  assert.strictEqual(await store.getRoleId('guild-1', 'user-1'), 'role-abc');
+  assert.deepStrictEqual(await store.getColorConfig('guild-1', 'user-1'), gradient);
+  assert.strictEqual(await store.getEmblem('guild-1', 'user-1'), null);
+
+  await store.setRoleId('guild-1', 'user-1', null);
+  assert.strictEqual(await store.getRoleId('guild-1', 'user-1'), null);
+  assert.deepStrictEqual(await store.getColorConfig('guild-1', 'user-1'), gradient);
+
+  await store.setColorConfig('guild-1', 'user-1', null);
+  assert.strictEqual(await store.getRoleId('guild-1', 'user-1'), null);
+  assert.strictEqual(await store.getColorConfig('guild-1', 'user-1'), null);
+  assert.strictEqual(await store.getEmblem('guild-1', 'user-1'), null);
+  assert.deepStrictEqual(await store.listBoosters('guild-1'), []);
+});
+
+test('removeByRoleId removes matching booster entries', async () => {
+  await resetStoreFile();
+  const store = loadStore();
+
+  await store.setRoleId('guild-2', 'user-2', 'role-xyz');
+  await store.setColorConfig('guild-2', 'user-2', { mode: 'solid', colors: ['#ABCDEF'] });
+
+  await store.removeByRoleId('guild-2', 'role-xyz');
+
+  assert.strictEqual(await store.getRoleId('guild-2', 'user-2'), null);
+  assert.strictEqual(await store.getColorConfig('guild-2', 'user-2'), null);
+  assert.strictEqual(await store.getEmblem('guild-2', 'user-2'), null);
+  assert.deepStrictEqual(await store.listBoosters('guild-2'), []);
+});
+
+test('setEmblem stores metadata and cleans up files when removed', async () => {
+  await resetStoreFile();
+  const store = loadStore();
+
+  const emblemPath = path.join('booster-emblems', 'guild-3', 'user-3.png');
+  const absolutePath = path.join(tempDir, emblemPath);
+  await fs.promises.mkdir(path.dirname(absolutePath), { recursive: true });
+  await fs.promises.writeFile(absolutePath, 'fake');
+
+  await store.setRoleId('guild-3', 'user-3', 'role-789');
+  await store.setEmblem('guild-3', 'user-3', {
+    file: emblemPath,
+    contentType: 'image/png',
+    uploadedAt: '2024-01-01T00:00:00.000Z',
+    name: 'icon.png',
+  });
+
+  const stored = await store.getEmblem('guild-3', 'user-3');
+  assert.deepStrictEqual(stored, {
+    file: emblemPath,
+    contentType: 'image/png',
+    uploadedAt: '2024-01-01T00:00:00.000Z',
+    name: 'icon.png',
+  });
+
+  assert.strictEqual(fs.existsSync(absolutePath), true);
+
+  await store.setEmblem('guild-3', 'user-3', null);
+  assert.strictEqual(await store.getEmblem('guild-3', 'user-3'), null);
+  assert.strictEqual(fs.existsSync(absolutePath), false);
+
+  assert.deepStrictEqual(await store.listBoosters('guild-3'), [
+    { userId: 'user-3', roleId: 'role-789', color: null, emblem: null },
+  ]);
+});
+
+test('guild configuration defaults to enabled and can be toggled', async () => {
+  await resetStoreFile();
+  const store = loadStore();
+
+  assert.deepStrictEqual(await store.getGuildConfig('guild-4'), { enabled: true });
+  assert.strictEqual(await store.isGuildEnabled('guild-4'), true);
+
+  await store.setGuildEnabled('guild-4', false);
+  assert.deepStrictEqual(await store.getGuildConfig('guild-4'), { enabled: false });
+  assert.strictEqual(await store.isGuildEnabled('guild-4'), false);
+
+  await store.setGuildEnabled('guild-4', true);
+  assert.deepStrictEqual(await store.getGuildConfig('guild-4'), { enabled: true });
+  assert.strictEqual(await store.isGuildEnabled('guild-4'), true);
+});


### PR DESCRIPTION
## Summary
- add a `/bremblem` command so boosters can upload or clear custom emblems for their role
- expand the booster role manager to download, validate, persist, and reapply emblem assets alongside colour updates
- extend the booster role store and its tests to track emblem metadata and clean up saved files when data is cleared
- add a `/brconfig` command so guild staff can enable or disable booster roles, persisting the choice per guild
- add a `/brsync` command and manager helper to assign roles to existing boosters and report any errors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce35f385a083319252c142b82f84b5