### PR TITLE
Add slash commands for image utilities and server assets

### DIFF
--- a/src/commands/avatar.js
+++ b/src/commands/avatar.js
@@ -1,0 +1,43 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+
+function buildAvatarLinks(user) {
+  const size = 4096;
+  const animated = Boolean(user.avatar && user.avatar.startsWith('a_'));
+  const formats = animated ? ['gif', 'png', 'jpeg', 'webp'] : ['png', 'jpeg', 'webp'];
+  return formats
+    .map(fmt => {
+      const url = user.displayAvatarURL({ size, extension: fmt, forceStatic: fmt === 'gif' ? false : true });
+      const label = fmt.toUpperCase();
+      return `[${label}](${url})`;
+    })
+    .join(' • ');
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('avatar')
+    .setDescription("Display a user's avatar")
+    .addUserOption(opt =>
+      opt
+        .setName('user')
+        .setDescription('User to lookup (defaults to you)')
+        .setRequired(false)
+    ),
+
+  async execute(interaction) {
+    const target = interaction.options.getUser('user') ?? interaction.user;
+    const links = buildAvatarLinks(target);
+    const displayUrl = target.displayAvatarURL({ size: 4096, extension: target.avatar?.startsWith('a_') ? 'gif' : 'png' });
+
+    const embed = new EmbedBuilder()
+      .setTitle(`${target.tag || target.username}'s avatar`)
+      .setDescription(links)
+      .setImage(displayUrl)
+      .setColor(0x5865F2)
+      .setFooter({ text: `Requested by ${interaction.user.tag || interaction.user.username}` })
+      .setTimestamp(Date.now());
+
+    await interaction.reply({ embeds: [embed] });
+  },
+};
+

--- a/src/commands/avatarhistory.js
+++ b/src/commands/avatarhistory.js
@@ -1,0 +1,90 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+// node-fetch v3 is ESM-only; use dynamic import in CommonJS
+const fetch = (...args) => import('node-fetch').then(({ default: fetch }) => fetch(...args));
+
+function deriveAvatarUrl(userId, entry) {
+  if (!entry) return null;
+  if (entry.url) return entry.url;
+  const hash = entry.avatar || entry.hash || entry.id;
+  if (!hash || typeof hash !== 'string') return null;
+  const ext = hash.startsWith('a_') ? 'gif' : 'png';
+  return `https://cdn.discordapp.com/avatars/${userId}/${hash}.${ext}?size=4096`;
+}
+
+function formatTimestamp(entry) {
+  const ts = entry?.timestamp || entry?.time || entry?.created_at || entry?.updated_at;
+  if (!ts) return null;
+  const ms = typeof ts === 'number' ? ts : Date.parse(ts);
+  if (Number.isNaN(ms)) return null;
+  return Math.floor(ms / 1000);
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('avatarhistory')
+    .setDescription("Display a user's last 6 avatars")
+    .addUserOption(opt =>
+      opt
+        .setName('user')
+        .setDescription('User to inspect (defaults to you)')
+        .setRequired(false)
+    ),
+
+  async execute(interaction) {
+    const target = interaction.options.getUser('user') ?? interaction.user;
+    await interaction.deferReply();
+
+    try {
+      const endpoint = `https://discordlookup.mesalytic.moe/v1/avatarhistory/${target.id}`;
+      const response = await fetch(endpoint, {
+        headers: { 'User-Agent': 'DusscordBot/1.0 (+https://github.com/)' },
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const data = await response.json();
+      const history = Array.isArray(data?.history)
+        ? data.history
+        : Array.isArray(data?.avatars)
+          ? data.avatars
+          : [];
+
+      const limited = history.slice(0, 6);
+      const lines = [];
+      for (let i = 0; i < limited.length; i++) {
+        const entry = limited[i];
+        const url = deriveAvatarUrl(target.id, entry);
+        if (!url) continue;
+        const timestamp = formatTimestamp(entry);
+        const timeText = timestamp ? ` — <t:${timestamp}:R>` : '';
+        lines.push(`**${i + 1}.** [View Avatar](${url})${timeText}`);
+      }
+
+      if (lines.length === 0) {
+        await interaction.editReply({
+          content: "I couldn't find any avatar history for that user.",
+        });
+        return;
+      }
+
+      const embed = new EmbedBuilder()
+        .setTitle(`${target.tag || target.username}'s recent avatars`)
+        .setDescription(lines.join('\n'))
+        .setThumbnail(target.displayAvatarURL({ size: 256 }))
+        .setColor(0x5865F2);
+
+      await interaction.editReply({
+        content: null,
+        embeds: [embed],
+      });
+    } catch (error) {
+      console.error('Failed to load avatar history:', error);
+      await interaction.editReply({
+        content: 'Sorry, I was unable to fetch that avatar history right now.',
+      });
+    }
+  },
+};
+

--- a/src/commands/imageresize.js
+++ b/src/commands/imageresize.js
@@ -1,0 +1,89 @@
+const { SlashCommandBuilder, AttachmentBuilder } = require('discord.js');
+// node-fetch v3 is ESM-only; use dynamic import in CommonJS
+const fetch = (...args) => import('node-fetch').then(({ default: fetch }) => fetch(...args));
+
+function buildProxyUrl(originalUrl, width, height) {
+  const parsed = new URL(originalUrl);
+  const path = `${parsed.host}${parsed.pathname}${parsed.search || ''}`;
+  const proxied = parsed.protocol === 'https:' ? `ssl:${path}` : path;
+
+  const proxy = new URL('https://images.weserv.nl/');
+  proxy.searchParams.set('url', proxied);
+  proxy.searchParams.set('output', 'png');
+  if (width) proxy.searchParams.set('w', String(width));
+  if (height) proxy.searchParams.set('h', String(height));
+  proxy.searchParams.set('fit', 'inside');
+  proxy.searchParams.set('we', '1');
+  return proxy;
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('imageresize')
+    .setDescription('Resize an image and convert it to PNG')
+    .addAttachmentOption(opt =>
+      opt
+        .setName('image')
+        .setDescription('Image attachment to resize')
+        .setRequired(true)
+    )
+    .addIntegerOption(opt =>
+      opt
+        .setName('width')
+        .setDescription('Target width in pixels (max 4096)')
+        .setMinValue(1)
+        .setMaxValue(4096)
+        .setRequired(true)
+    )
+    .addIntegerOption(opt =>
+      opt
+        .setName('height')
+        .setDescription('Target height in pixels (optional, max 4096). Leave empty to auto-scale.')
+        .setMinValue(1)
+        .setMaxValue(4096)
+        .setRequired(false)
+    ),
+
+  async execute(interaction) {
+    const attachment = interaction.options.getAttachment('image', true);
+    const width = interaction.options.getInteger('width', true);
+    const height = interaction.options.getInteger('height');
+
+    if (!attachment.contentType || !attachment.contentType.startsWith('image/')) {
+      await interaction.reply({
+        content: 'Please provide a valid image attachment.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    await interaction.deferReply();
+
+    try {
+      const proxyUrl = buildProxyUrl(attachment.url, width, height ?? undefined);
+      const response = await fetch(proxyUrl);
+      if (!response.ok) {
+        throw new Error(`Proxy response ${response.status}`);
+      }
+
+      const buffer = await response.buffer();
+      if (!buffer || buffer.length === 0) {
+        throw new Error('Received empty image buffer');
+      }
+
+      const fileName = `resized-${Date.now()}.png`;
+      const file = new AttachmentBuilder(buffer, { name: fileName });
+
+      await interaction.editReply({
+        content: `Resized image to ${width}px${height ? ` × ${height}px` : ''} (PNG).`,
+        files: [file],
+      });
+    } catch (error) {
+      console.error('Failed to resize image:', error);
+      await interaction.editReply({
+        content: 'Sorry, I could not resize that image. Please try a different image or dimensions.',
+      });
+    }
+  },
+};
+

--- a/src/commands/serverbanner.js
+++ b/src/commands/serverbanner.js
@@ -1,0 +1,38 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('serverbanner')
+    .setDescription("Display this server's banner")
+    .setDMPermission(false),
+
+  async execute(interaction) {
+    const guild = interaction.guild;
+    if (!guild) {
+      await interaction.reply({ content: 'This command can only be used inside a server.', ephemeral: true });
+      return;
+    }
+
+    const banner = guild.bannerURL({ size: 4096 });
+    if (!banner) {
+      await interaction.reply({ content: 'This server does not have a banner configured.', ephemeral: true });
+      return;
+    }
+
+    const animated = Boolean(guild.banner && guild.banner.startsWith('a_'));
+    const formats = animated ? ['gif', 'png', 'jpeg', 'webp'] : ['png', 'jpeg', 'webp'];
+    const links = formats
+      .map(fmt => `[${fmt.toUpperCase()}](${guild.bannerURL({ size: 4096, extension: fmt })})`)
+      .join(' • ');
+
+    const embed = new EmbedBuilder()
+      .setTitle(`${guild.name} server banner`)
+      .setDescription(links)
+      .setImage(banner)
+      .setColor(0x5865F2)
+      .setTimestamp(Date.now());
+
+    await interaction.reply({ embeds: [embed] });
+  },
+};
+

--- a/src/commands/serverlogo.js
+++ b/src/commands/serverlogo.js
@@ -1,0 +1,38 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('serverlogo')
+    .setDescription("Display this server's icon")
+    .setDMPermission(false),
+
+  async execute(interaction) {
+    const guild = interaction.guild;
+    if (!guild) {
+      await interaction.reply({ content: 'This command can only be used in a server.', ephemeral: true });
+      return;
+    }
+
+    const icon = guild.iconURL({ size: 4096 });
+    if (!icon) {
+      await interaction.reply({ content: 'This server does not have an icon set.', ephemeral: true });
+      return;
+    }
+
+    const animated = Boolean(guild.icon && guild.icon.startsWith('a_'));
+    const formats = animated ? ['gif', 'png', 'jpeg', 'webp'] : ['png', 'jpeg', 'webp'];
+    const links = formats
+      .map(fmt => `[${fmt.toUpperCase()}](${guild.iconURL({ size: 4096, extension: fmt })})`)
+      .join(' • ');
+
+    const embed = new EmbedBuilder()
+      .setTitle(`${guild.name} server icon`)
+      .setDescription(links)
+      .setImage(icon)
+      .setColor(0x5865F2)
+      .setTimestamp(Date.now());
+
+    await interaction.reply({ embeds: [embed] });
+  },
+};
+


### PR DESCRIPTION
## Summary
- add `/imageresize` command to proxy-resize attachments to PNG output
- expose `/avatar` and `/avatarhistory` commands for user imagery
- provide `/serverlogo` and `/serverbanner` commands to fetch guild assets

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d762a74d8c8331a97637d40d7e664b