### PR TITLE
Add smite inventory and configuration options

### DIFF
--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -15,7 +15,8 @@ const categories = {
     { cmd: '/blacklist add/remove/list', desc: 'Manage the blacklist to auto-ban users on join', perm: 'Ban Members' },
     { cmd: '/purge', desc: 'Delete 1–100 recent messages in this channel', perm: 'Manage Messages' },
     { cmd: '/jail config/add/remove/status', desc: 'Jail members, remove roles, and restore them later', perm: 'Manage Roles' },
-    { cmd: '/drugscordbag', desc: 'Spend a Smite to timeout a user for up to 10 minutes', perm: null },
+    { cmd: '/smite', desc: 'Smite a non staff user, silencing them for 10 minutes', perm: null },
+    { cmd: '/smiteconfig', desc: 'Enable or disable Smite rewards and commands', perm: 'Manage Server' },
   ],
   'Roles & Verification': [
     { cmd: '/autoroles add/remove/list/clear', desc: 'Auto-assign roles to new members', perm: 'Manage Roles' },
@@ -64,6 +65,7 @@ const categories = {
   'Info & Utilities': [
     { cmd: '/joins leaderboard/user/setlog/backfill', desc: 'Join/leave stats; setup/backfill require Manage Server', perm: null },
     { cmd: '/botinfo', desc: 'Show bot instance, mode, commands loaded, and uptime', perm: null },
+    { cmd: '/inventory', desc: 'Check how many Smites you have and when you earn the next one', perm: null },
     { cmd: '/webhooks', desc: 'List server webhooks and their creators', perm: 'Manage Webhooks' },
     { cmd: '/servertag set/show/clear', desc: 'Manage the saved server tag for quick reference', perm: 'Manage Server' },
   ],

--- a/src/commands/inventory.js
+++ b/src/commands/inventory.js
@@ -1,0 +1,35 @@
+const { SlashCommandBuilder } = require('discord.js');
+const tokenStore = require('../utils/messageTokenStore');
+const smiteConfigStore = require('../utils/smiteConfigStore');
+
+const BAG_LABEL = 'Smite';
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('inventory')
+    .setDescription('Check how many Smites you currently have available'),
+
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ content: 'Use this command in a server to view your items.', ephemeral: true });
+    }
+
+    await interaction.deferReply({ ephemeral: true });
+
+    const { tokens, messagesUntilNext } = tokenStore.getProgress(interaction.guildId, interaction.user.id);
+    const plural = tokens === 1 ? '' : 's';
+    const baseLine = `You have ${tokens} ${BAG_LABEL}${plural}.`;
+
+    const nextLine = messagesUntilNext > 0
+      ? `Next ${BAG_LABEL} in ${messagesUntilNext} message${messagesUntilNext === 1 ? '' : 's'}.`
+      : `You're due for a ${BAG_LABEL} on your next message!`;
+
+    const smiteEnabled = smiteConfigStore.isEnabled(interaction.guildId);
+    const statusLine = smiteEnabled
+      ? 'Smite rewards are currently enabled on this server.'
+      : 'Smite rewards are currently disabled on this server.';
+
+    const response = `${baseLine} ${nextLine} ${statusLine}`.slice(0, 1900);
+    await interaction.editReply({ content: response });
+  },
+};

--- a/src/commands/smite.js
+++ b/src/commands/smite.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, PermissionsBitField } = require('discord.js');
 const tokenStore = require('../utils/messageTokenStore');
+const smiteConfigStore = require('../utils/smiteConfigStore');
 const securityLogger = require('../utils/securityLogger');
 const modLogger = require('../utils/modLogger');
 
@@ -16,8 +17,8 @@ const PROTECTED_PERMISSIONS = new PermissionsBitField([
 
 module.exports = {
   data: new SlashCommandBuilder()
-    .setName('drugscordbag')
-    .setDescription('Spend a Smite to timeout a user for up to 10 minutes.')
+    .setName('smite')
+    .setDescription('Smite a non staff user, silencing them for 10 minutes')
     .addUserOption(opt =>
       opt
         .setName('target')
@@ -43,11 +44,15 @@ module.exports = {
       return interaction.reply({ content: 'Use this command in a server.', ephemeral: true });
     }
 
+    if (!smiteConfigStore.isEnabled(interaction.guildId)) {
+      return interaction.reply({ content: 'Smite is disabled on this server.', ephemeral: true });
+    }
+
     await interaction.deferReply({ ephemeral: true });
 
     const me = interaction.guild.members.me;
     if (!me.permissions.has(PermissionsBitField.Flags.ModerateMembers)) {
-      await securityLogger.logPermissionDenied(interaction, 'drugscordbag', 'Bot missing Moderate Members');
+      await securityLogger.logPermissionDenied(interaction, 'smite', 'Bot missing Moderate Members');
       return interaction.editReply({ content: 'I need the Moderate Members permission to spend Smites.' });
     }
 
@@ -79,7 +84,7 @@ module.exports = {
     }
 
     if (targetMember.permissions.has(PROTECTED_PERMISSIONS)) {
-      await securityLogger.logPermissionDenied(interaction, 'drugscordbag', 'Target has protected permissions', [
+      await securityLogger.logPermissionDenied(interaction, 'smite', 'Target has protected permissions', [
         { name: 'Target', value: `${targetUser.tag} (${targetUser.id})`, inline: false },
       ]);
       return interaction.editReply({ content: 'You cannot spend Smites on moderators or administrators.' });
@@ -87,14 +92,14 @@ module.exports = {
 
     const meHigher = me.roles.highest.comparePositionTo(targetMember.roles.highest) > 0;
     if (!meHigher || !targetMember.moderatable) {
-      await securityLogger.logHierarchyViolation(interaction, 'drugscordbag', targetMember, 'Bot lower than target or not moderatable');
+      await securityLogger.logHierarchyViolation(interaction, 'smite', targetMember, 'Bot lower than target or not moderatable');
       return interaction.editReply({ content: "I can't timeout that member due to role hierarchy or permissions." });
     }
 
     const requesterHigher = interaction.member.roles.highest.comparePositionTo(targetMember.roles.highest) > 0
       || interaction.guild.ownerId === interaction.user.id;
     if (!requesterHigher) {
-      await securityLogger.logHierarchyViolation(interaction, 'drugscordbag', targetMember, 'Requester lower or equal to target');
+      await securityLogger.logHierarchyViolation(interaction, 'smite', targetMember, 'Requester lower or equal to target');
       return interaction.editReply({ content: "You can't timeout someone with an equal or higher role." });
     }
 

--- a/src/commands/smiteconfig.js
+++ b/src/commands/smiteconfig.js
@@ -1,0 +1,37 @@
+const { SlashCommandBuilder, PermissionsBitField } = require('discord.js');
+const smiteConfigStore = require('../utils/smiteConfigStore');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('smiteconfig')
+    .setDescription('Enable or disable Smite rewards and the /smite command')
+    .addBooleanOption(opt =>
+      opt
+        .setName('enabled')
+        .setDescription('Turn Smite rewards on or off')
+        .setRequired(false)
+    ),
+
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ content: 'Use this in a server.', ephemeral: true });
+    }
+
+    await interaction.deferReply({ ephemeral: true });
+
+    if (!interaction.member.permissions?.has(PermissionsBitField.Flags.ManageGuild)) {
+      return interaction.editReply({ content: 'You need the Manage Server permission to configure Smites.' });
+    }
+
+    const choice = interaction.options.getBoolean('enabled');
+    if (choice === null) {
+      const current = smiteConfigStore.getConfig(interaction.guildId);
+      const status = current.enabled ? 'enabled' : 'disabled';
+      return interaction.editReply({ content: `Smite rewards are currently **${status}** on this server.` });
+    }
+
+    const result = await smiteConfigStore.setEnabled(interaction.guildId, choice);
+    const status = result.enabled ? 'enabled' : 'disabled';
+    await interaction.editReply({ content: `Smite rewards have been **${status}**.` });
+  },
+};

--- a/src/events/messageCreate.smites.js
+++ b/src/events/messageCreate.smites.js
@@ -1,5 +1,6 @@
 const { Events } = require('discord.js');
 const bagStore = require('../utils/messageTokenStore');
+const smiteConfigStore = require('../utils/smiteConfigStore');
 
 const BAG_LABEL = 'Smite';
 
@@ -9,6 +10,7 @@ module.exports = {
     try {
       if (!message?.guild) return;
       if (message.author?.bot) return;
+      if (!smiteConfigStore.isEnabled(message.guild.id)) return;
 
       const result = await bagStore.incrementMessage(message.guild.id, message.author.id);
       if (!result || !result.awarded) return;
@@ -21,16 +23,13 @@ module.exports = {
       const base = `You just earned ${awardedBags} ${BAG_LABEL}${pluralAward} in ${message.guild.name}!`;
       const totalLine = `You now have ${totalBags} ${BAG_LABEL}${pluralTotal}.`;
       const nextLine = `Next Smite in ${nextIn} message${nextIn === 1 ? '' : 's'}.`;
-      const content = `${base} ${totalLine} ${nextLine}`.slice(0, 1900);
+      const hintLine = 'Check `/inventory` anytime to view your items.';
+      const content = `${base} ${totalLine} ${nextLine} ${hintLine}`.slice(0, 1900);
 
       try {
-        await message.author.send({ content });
+        await message.reply({ content, allowedMentions: { repliedUser: false } });
       } catch (_) {
-        try {
-          await message.reply({ content, allowedMentions: { repliedUser: false } });
-        } catch (_) {
-          // ignore if we cannot notify the user
-        }
+        // ignore if we cannot notify the user
       }
     } catch (err) {
       console.error('Failed to process Smite increment', err);

--- a/src/utils/smiteConfigStore.js
+++ b/src/utils/smiteConfigStore.js
@@ -1,0 +1,82 @@
+const { ensureFileSync, writeJson, readJsonSync } = require('./dataDir');
+
+const STORE_FILE = 'smite_config.json';
+let cache = null;
+
+function ensureStore() {
+  ensureFileSync(STORE_FILE, { guilds: {} });
+}
+
+function loadStore() {
+  if (cache) return cache;
+  ensureStore();
+  try {
+    const data = readJsonSync(STORE_FILE, { guilds: {} });
+    if (!data || typeof data !== 'object') {
+      cache = { guilds: {} };
+    } else {
+      if (!data.guilds || typeof data.guilds !== 'object') data.guilds = {};
+      cache = data;
+    }
+  } catch (err) {
+    console.error('Failed to load smite config store', err);
+    cache = { guilds: {} };
+  }
+  return cache;
+}
+
+async function saveStore() {
+  const store = loadStore();
+  const safe = store && typeof store === 'object' ? store : { guilds: {} };
+  if (!safe.guilds || typeof safe.guilds !== 'object') safe.guilds = {};
+  await writeJson(STORE_FILE, safe);
+}
+
+function getGuildRecord(guildId) {
+  const store = loadStore();
+  if (!store.guilds[guildId] || typeof store.guilds[guildId] !== 'object') {
+    store.guilds[guildId] = { enabled: true };
+  }
+  const guild = store.guilds[guildId];
+  if (typeof guild.enabled !== 'boolean') guild.enabled = true;
+  return guild;
+}
+
+function getConfig(guildId) {
+  if (!guildId) {
+    return { enabled: true, updatedAt: null };
+  }
+  const guild = getGuildRecord(guildId);
+  return {
+    enabled: guild.enabled !== false,
+    updatedAt: guild.updatedAt ?? null,
+  };
+}
+
+function isEnabled(guildId) {
+  return getConfig(guildId).enabled;
+}
+
+async function setEnabled(guildId, enabled) {
+  if (!guildId) {
+    return { enabled: true, updatedAt: null };
+  }
+  const store = loadStore();
+  store.guilds[guildId] = {
+    enabled: !!enabled,
+    updatedAt: new Date().toISOString(),
+  };
+  await saveStore();
+  return getConfig(guildId);
+}
+
+function clearCache() {
+  cache = null;
+}
+
+module.exports = {
+  getConfig,
+  isEnabled,
+  setEnabled,
+  clearCache,
+};

--- a/tests/smiteConfigStore.test.js
+++ b/tests/smiteConfigStore.test.js
@@ -1,0 +1,54 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const modulePath = require.resolve('../src/utils/smiteConfigStore');
+const dataDirPath = require.resolve('../src/utils/dataDir');
+
+async function withTempStore(fn) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'smite-config-'));
+  delete require.cache[modulePath];
+  delete require.cache[dataDirPath];
+  process.env.DUSSCORD_DATA_DIR = tmpDir;
+  const store = require(modulePath);
+  try {
+    await fn(store, tmpDir);
+  } finally {
+    delete require.cache[modulePath];
+    delete require.cache[dataDirPath];
+    if (store?.clearCache) store.clearCache();
+    delete require.cache[modulePath];
+    delete process.env.DUSSCORD_DATA_DIR;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+test('defaults to enabled when no config exists', async () => {
+  await withTempStore(async store => {
+    const config = store.getConfig('guild');
+    assert.equal(config.enabled, true);
+    assert.equal(store.isEnabled('guild'), true);
+  });
+});
+
+test('setEnabled persists preference to disk', async () => {
+  await withTempStore(async (store, dir) => {
+    const guildId = 'guild';
+    const result = await store.setEnabled(guildId, false);
+    assert.equal(result.enabled, false);
+    assert.equal(store.isEnabled(guildId), false);
+
+    const file = path.join(process.env.DUSSCORD_DATA_DIR, 'smite_config.json');
+    assert.ok(fs.existsSync(file));
+    const saved = JSON.parse(fs.readFileSync(file, 'utf8'));
+    assert.equal(saved.guilds[guildId].enabled, false);
+
+    // Re-require to ensure persistence
+    store.clearCache();
+    delete require.cache[modulePath];
+    const reloaded = require(modulePath);
+    assert.equal(reloaded.isEnabled(guildId), false);
+  });
+});


### PR DESCRIPTION
## Summary
- rename the Smite timeout command to /smite and gate it behind a guild toggle
- add /inventory plus in-channel Smite notifications instead of DMs
- provide smite configuration storage, commands, and tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7679de44c83319d3177bc3124feb5