### PR TITLE
Refine help menu categories for admin and owner commands

### DIFF
--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -12,43 +12,44 @@ const categories = {
     { cmd: '/mute', desc: 'Timeout a member for a set duration (reason required)', perm: 'Moderate Members' },
     { cmd: '/kick', desc: 'Kick a member (reason required)', perm: 'Kick Members' },
     { cmd: '/ban', desc: 'Ban a user; optional prune_days (0–7)', perm: 'Ban Members' },
-    { cmd: '/blacklist add/remove/list', desc: 'Manage the blacklist to auto-ban users on join', perm: 'Ban Members' },
-    { cmd: '/purge', desc: 'Delete 1–100 recent messages in this channel', perm: 'Manage Messages' },
-    { cmd: '/jail config/add/remove/status', desc: 'Jail members, remove roles, and restore them later', perm: 'Manage Roles' },
     { cmd: '/smite', desc: 'Smite a non staff user, silencing them for 10 minutes', perm: null },
-    { cmd: '/smiteconfig', desc: 'Enable or disable Smite rewards and commands', perm: 'Manage Server' },
   ],
-  'Roles & Verification': [
+  Administrator: [
+    { cmd: '/purge', desc: 'Delete 1–100 recent messages in this channel', perm: 'Manage Messages' },
+    { cmd: '/blacklist add/remove/list', desc: 'Manage the blacklist to auto-ban users on join', perm: 'Ban Members' },
+    { cmd: '/jail config/add/remove/status', desc: 'Jail members, remove roles, and restore them later', perm: 'Manage Roles' },
     { cmd: '/autoroles add/remove/list/clear', desc: 'Auto-assign roles to new members', perm: 'Manage Roles' },
     { cmd: '/role add/remove', desc: 'Add or remove a specific role from a member', perm: 'Manage Roles' },
     { cmd: '/createrole', desc: 'Create a role with colour/hoist/mentionable options', perm: 'Manage Roles' },
     { cmd: '/deleterole', desc: 'Delete a role from the server', perm: 'Manage Roles' },
     { cmd: '/reactionrole create', desc: 'Post an embed with a selectable role menu', perm: 'Manage Roles' },
     { cmd: '/verify setup/status/disable/repost', desc: 'Verification button + role assignment with account-age checks', perm: 'Manage Server' },
-  ],
-  'Server Setup & Messaging': [
+    { cmd: '/smiteconfig', desc: 'Enable or disable Smite rewards and commands', perm: 'Manage Server' },
     { cmd: '/welcome setup/status/disable/test', desc: 'Configure a welcome embed for new members', perm: 'Manage Server' },
     { cmd: '/leave setup/status/disable/test', desc: 'Configure a leave embed for departing members', perm: 'Manage Server' },
     { cmd: '/confessconfig', desc: 'Send the anonymous confession button to a channel', perm: 'Manage Server' },
     { cmd: '/autorespond toggle/add/remove/list', desc: 'Keyword autoresponses with optional channel filters', perm: 'Administrator' },
     { cmd: '/repeat start/stop/list', desc: 'Schedule repeating messages every N seconds (>=60)', perm: 'Administrator' },
     { cmd: '/say', desc: 'Send a custom message as the bot (optional target channel)', perm: 'Administrator' },
-  ],
-  'Embeds & Styling': [
-    { cmd: '/embed create/quick', desc: 'Interactive modal or quick embed sender', perm: null },
-    { cmd: '/getembed', desc: 'Extract embed JSON from a message', perm: null },
-    { cmd: '/colour set/get/reset', desc: 'Manage the default embed colour for this server', perm: 'Manage Server' },
-  ],
-  'Channels & Logs': [
+    { cmd: '/transcribe config', desc: 'Configure automatic voice transcription destinations', perm: 'Manage Server' },
+    { cmd: '/brconfig', desc: 'Enable or disable automatic booster custom roles', perm: 'Manage Server' },
+    { cmd: '/brsync', desc: 'Sync booster custom roles for existing boosters', perm: 'Manage Server' },
     { cmd: '/createchannel', desc: 'Create text/voice/stage channels with optional category', perm: 'Manage Channels' },
     { cmd: '/channelsync', desc: 'Sync child channels with their category permissions', perm: 'Manage Channels' },
     { cmd: '/logchannels add/remove/list', desc: 'Monitor channels for admin deletions (DM owners)', perm: 'Manage Channels' },
     { cmd: '/logconfig', desc: 'Show status of security/mod/stream log settings', perm: 'Manage Server' },
     { cmd: '/logstream setchannel/toggle/show', desc: 'Stream real-time event logs to a channel', perm: 'Manage Server' },
     { cmd: '/modlog set/mode/toggle/show', desc: 'Configure moderation action logging outputs', perm: 'Manage Server' },
-    { cmd: '/securitylog set/mode/clear/toggle/show', desc: 'Configure security log delivery and enablement', perm: 'Manage Server' },
     { cmd: '/securityreport', desc: 'Report members triggering permission/hierarchy issues', perm: 'Manage Server' },
     { cmd: '/antinuke config', desc: 'Configure anti-nuke protections and review status', perm: 'Manage Server' },
+    { cmd: '/joins leaderboard/user/setlog/backfill', desc: 'Join/leave stats; setup/backfill require Manage Server', perm: 'Manage Server' },
+    { cmd: '/avatarhistory', desc: 'View a user’s historical avatars via Discord Lookup', perm: null },
+    { cmd: '/webhooks', desc: 'List server webhooks and their creators', perm: 'Manage Webhooks' },
+    { cmd: '/embed create/quick', desc: 'Interactive modal or quick embed sender', perm: null },
+    { cmd: '/getembed', desc: 'Extract embed JSON from a message', perm: null },
+    { cmd: '/colour set/get/reset', desc: 'Manage the default embed colour for this server', perm: 'Manage Server' },
+    { cmd: '/config getdefaultcolour', desc: 'Show the configured default embed colour for this server', perm: null },
+    { cmd: '/servertag set/show/clear', desc: 'Manage the saved server tag for quick reference', perm: 'Manage Server' },
   ],
   'Emoji & Stickers': [
     { cmd: '/clone emoji/sticker', desc: 'Clone emojis or stickers via mention, ID, URL, or upload', perm: 'Manage Emojis and Stickers' },
@@ -60,20 +61,17 @@ const categories = {
     { cmd: '/summarize', desc: 'Summarize recent channel messages into bullets and a paragraph', perm: null },
     { cmd: '/transcribe', desc: 'Transcribe an attached audio file using Whisper', perm: null },
     { cmd: '/removebg', desc: 'Remove an image background via remove.bg', perm: null },
-    { cmd: '/voiceauto enable/disable/status', desc: 'Auto-transcribe voice messages into configured channels', perm: 'Manage Server' },
   ],
   'Info & Utilities': [
-    { cmd: '/joins leaderboard/user/setlog/backfill', desc: 'Join/leave stats; setup/backfill require Manage Server', perm: null },
     { cmd: '/botinfo', desc: 'Show bot instance, mode, commands loaded, and uptime', perm: null },
     { cmd: '/inventory', desc: 'Check how many Smites you have and when you earn the next one', perm: null },
-    { cmd: '/webhooks', desc: 'List server webhooks and their creators', perm: 'Manage Webhooks' },
-    { cmd: '/servertag set/show/clear', desc: 'Manage the saved server tag for quick reference', perm: 'Manage Server' },
   ],
-  'Owner Only': [
+  'Bot Owner': [
     { cmd: '/adminlist', desc: 'List mutual guilds where a user has Administrator', perm: 'Bot Owner' },
     { cmd: '/botlook', desc: 'Update the bot avatar, nickname, or bio', perm: 'Bot Owner' },
     { cmd: '/dmdiag test/role', desc: 'DM diagnostics for a member or role', perm: 'Bot Owner' },
     { cmd: '/wraith start/stop', desc: 'Create a private spam channel and isolate a member', perm: 'Bot Owner' },
+    { cmd: '/securitylog set/mode/clear/toggle/show', desc: 'Configure security log delivery and enablement', perm: 'Bot Owner' },
   ],
 };
 
@@ -82,21 +80,9 @@ const categoryMeta = {
     emoji: '🛡️',
     blurb: 'Keep your community safe with powerful moderation tools.',
   },
-  'Roles & Verification': {
-    emoji: '🧩',
-    blurb: 'Streamline onboarding with smart role and verification helpers.',
-  },
-  'Server Setup & Messaging': {
-    emoji: '🏗️',
-    blurb: 'Automate announcements and set your server’s tone.',
-  },
-  'Embeds & Styling': {
-    emoji: '🎨',
-    blurb: 'Craft gorgeous embeds and set a cohesive style.',
-  },
-  'Channels & Logs': {
-    emoji: '🛰️',
-    blurb: 'Create, sync, and monitor channels with ease.',
+  Administrator: {
+    emoji: '🧰',
+    blurb: 'Server-wide configuration, logging, and automation tools.',
   },
   'Emoji & Stickers': {
     emoji: '😄',
@@ -110,7 +96,7 @@ const categoryMeta = {
     emoji: '🧭',
     blurb: 'Discover stats, diagnostics, and handy utilities.',
   },
-  'Owner Only': {
+  'Bot Owner': {
     emoji: '👑',
     blurb: 'Exclusive controls reserved for bot owners.',
   },
@@ -144,7 +130,7 @@ function buildEmbed(categoryName, includeOwner, guildId, botUser) {
   } catch (_) {}
 
   if (categoryName && categories[categoryName]) {
-    if (categoryName === 'Owner Only' && !includeOwner) {
+    if (categoryName === 'Bot Owner' && !includeOwner) {
       embed.setDescription('Owner-only commands are hidden.');
       return embed;
     }
@@ -163,7 +149,7 @@ function buildEmbed(categoryName, includeOwner, guildId, botUser) {
 
   embed.setDescription('✨ Explore the command vault and find the perfect tool in seconds.');
   const cats = Object.keys(categories).filter(
-    (cat) => !(cat === 'Owner Only' && !includeOwner)
+    (cat) => !(cat === 'Bot Owner' && !includeOwner)
   );
   const value = cats
     .map((c) => {
@@ -197,7 +183,7 @@ module.exports = {
     );
 
     const options = Object.keys(categories)
-      .filter((c) => !(c === 'Owner Only' && !owner))
+      .filter((c) => !(c === 'Bot Owner' && !owner))
       .map((c) => {
         const meta = categoryMeta[c] ?? {};
         const option = { label: c, value: c };


### PR DESCRIPTION
## Summary
- restructure the help menu to introduce an Administrator category that groups moderation setup, role, logging, and configuration commands requiring elevated permissions
- move security logging controls into a Bot Owner section that remains hidden from non-owners while leaving other categories visible to all users

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d771d9b16c8331863260a2a6b90253