### PR TITLE
Format transcripts and summaries as embeds

### DIFF
--- a/src/utils/embedFields.js
+++ b/src/utils/embedFields.js
@@ -1,0 +1,103 @@
+const { EmbedBuilder } = require('discord.js');
+
+const DEFAULT_COLOR = 0x5865F2;
+const FIELD_CHUNK_SIZE = 1024;
+const EMBED_CHAR_LIMIT = 6000;
+const MAX_FIELDS_PER_EMBED = 25;
+
+function chunkText(text, size = FIELD_CHUNK_SIZE) {
+  if (!text) return [];
+  const str = String(text);
+  const chunks = [];
+  for (let i = 0; i < str.length; i += size) {
+    chunks.push(str.slice(i, i + size));
+  }
+  return chunks;
+}
+
+function createFieldEmbeds({
+  title,
+  sections,
+  user,
+  description,
+  color = DEFAULT_COLOR,
+  inline = false,
+}) {
+  if (!Array.isArray(sections) || !sections.length) return [];
+
+  const avatarUrl = typeof user?.displayAvatarURL === 'function'
+    ? user.displayAvatarURL({ size: 256 })
+    : null;
+
+  const expandedFields = [];
+  for (const section of sections) {
+    if (!section || !section.name) continue;
+    const baseName = String(section.name);
+    const value = section.value == null ? '' : String(section.value);
+    const chunks = chunkText(value, FIELD_CHUNK_SIZE);
+    if (!chunks.length) {
+      expandedFields.push({ name: baseName, value: '\u200b', inline });
+      continue;
+    }
+    chunks.forEach((chunk, idx) => {
+      const name = chunks.length === 1
+        ? baseName
+        : `${baseName} (part ${idx + 1})`;
+      expandedFields.push({ name, value: chunk, inline });
+    });
+  }
+
+  const embeds = [];
+  let embedIndex = 0;
+  let currentEmbed = null;
+  let currentLength = 0;
+  let currentFieldCount = 0;
+
+  const startNewEmbed = () => {
+    const suffix = embedIndex === 0 ? '' : ` (cont. ${embedIndex})`;
+    const computedTitle = title ? `${title}${suffix}` : null;
+    currentEmbed = new EmbedBuilder()
+      .setColor(color);
+    if (computedTitle) {
+      currentEmbed.setTitle(computedTitle);
+    }
+    if (description && embedIndex === 0) {
+      currentEmbed.setDescription(description);
+      currentLength = description.length + (computedTitle ? computedTitle.length : 0);
+    } else {
+      currentLength = computedTitle ? computedTitle.length : 0;
+    }
+    if (avatarUrl && embedIndex === 0) {
+      currentEmbed.setThumbnail(avatarUrl);
+    }
+    currentFieldCount = 0;
+    embedIndex += 1;
+  };
+
+  for (const field of expandedFields) {
+    if (!currentEmbed) startNewEmbed();
+    const additionalLength = (field.name?.length || 0) + (field.value?.length || 0);
+    const wouldExceedLength = (currentLength + additionalLength) > EMBED_CHAR_LIMIT;
+    const wouldExceedCount = currentFieldCount >= MAX_FIELDS_PER_EMBED;
+
+    if (wouldExceedLength || wouldExceedCount) {
+      embeds.push(currentEmbed);
+      startNewEmbed();
+    }
+
+    currentEmbed.addFields(field);
+    currentLength += additionalLength;
+    currentFieldCount += 1;
+  }
+
+  if (currentEmbed) {
+    embeds.push(currentEmbed);
+  }
+
+  return embeds;
+}
+
+module.exports = {
+  chunkText,
+  createFieldEmbeds,
+};


### PR DESCRIPTION
## Summary
- add a reusable helper to split long text into embed field chunks
- return transcription responses as embeds featuring the requesting user's avatar
- render summarize command output in embed fields to support longer responses

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7772e1c34833194dc5102ea8ad0c9