### PR TITLE
Add givejudgement command and backing store

### DIFF
--- a/src/commands/givejudgement.js
+++ b/src/commands/givejudgement.js
@@ -1,0 +1,49 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { isOwner } = require('../utils/ownerIds');
+const judgementStore = require('../utils/judgementStore');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('givejudgement')
+    .setDescription('Grant judgement tokens to a user')
+    .addUserOption((option) =>
+      option
+        .setName('user')
+        .setDescription('User to receive judgement tokens')
+        .setRequired(true)
+    )
+    .addIntegerOption((option) =>
+      option
+        .setName('amount')
+        .setDescription('Number of judgement tokens to grant')
+        .setMinValue(1)
+    ),
+
+  async execute(interaction) {
+    if (!isOwner(interaction.user.id)) {
+      return interaction.reply({
+        content: 'Only bot owners can use this command.',
+        ephemeral: true,
+      });
+    }
+
+    const targetUser = interaction.options.getUser('user', true);
+    const amountInput = interaction.options.getInteger('amount');
+    const amount = Number.isFinite(amountInput) && amountInput > 0 ? amountInput : 1;
+
+    const guildId = interaction.guildId ?? interaction.guild?.id;
+    if (!guildId) {
+      return interaction.reply({
+        content: 'This command can only be used within a server.',
+        ephemeral: true,
+      });
+    }
+
+    const balance = await judgementStore.addTokens(guildId, targetUser.id, amount);
+
+    await interaction.reply({
+      content: `Granted ${amount} judgement token${amount === 1 ? '' : 's'} to ${targetUser}. They now have ${balance}.`,
+      ephemeral: true,
+    });
+  },
+};

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -69,6 +69,7 @@ const categories = {
   'Bot Owner': [
     { cmd: '/adminlist', desc: 'List mutual guilds where a user has Administrator', perm: 'Bot Owner' },
     { cmd: '/botlook', desc: 'Update the bot avatar, nickname, or bio', perm: 'Bot Owner' },
+    { cmd: '/givejudgement', desc: 'Grant judgement tokens to a user', perm: 'Bot Owner' },
     { cmd: '/dmdiag test/role', desc: 'DM diagnostics for a member or role', perm: 'Bot Owner' },
     { cmd: '/wraith start/stop', desc: 'Create a private spam channel and isolate a member', perm: 'Bot Owner' },
     { cmd: '/securitylog set/mode/clear/toggle/show', desc: 'Configure security log delivery and enablement', perm: 'Bot Owner' },

--- a/src/utils/judgementStore.js
+++ b/src/utils/judgementStore.js
@@ -1,0 +1,76 @@
+const fs = require('fs');
+const { ensureFileSync, resolveDataPath, writeJson } = require('./dataDir');
+
+const STORE_FILE = resolveDataPath('judgements.json');
+
+let cache = null;
+
+function ensureStoreFile() {
+  try {
+    ensureFileSync('judgements.json', { guilds: {} });
+  } catch (err) {
+    console.error('Failed to initialise judgement store', err);
+  }
+}
+
+function loadStore() {
+  if (cache) return cache;
+  ensureStoreFile();
+  try {
+    const raw = fs.readFileSync(STORE_FILE, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') {
+      cache = { guilds: {} };
+    } else {
+      if (!parsed.guilds || typeof parsed.guilds !== 'object') parsed.guilds = {};
+      cache = parsed;
+    }
+  } catch (err) {
+    cache = { guilds: {} };
+  }
+  return cache;
+}
+
+async function saveStore() {
+  ensureStoreFile();
+  const safe = cache && typeof cache === 'object' ? cache : { guilds: {} };
+  if (!safe.guilds || typeof safe.guilds !== 'object') safe.guilds = {};
+  await writeJson('judgements.json', safe);
+}
+
+function ensureRecord(guildId, userId) {
+  const store = loadStore();
+  if (!store.guilds[guildId] || typeof store.guilds[guildId] !== 'object') {
+    store.guilds[guildId] = { users: {} };
+  }
+  const guild = store.guilds[guildId];
+  if (!guild.users || typeof guild.users !== 'object') guild.users = {};
+  if (!guild.users[userId] || typeof guild.users[userId] !== 'object') {
+    guild.users[userId] = { tokens: 0 };
+  }
+  const rec = guild.users[userId];
+  if (!Number.isFinite(rec.tokens) || rec.tokens < 0) rec.tokens = 0;
+  rec.tokens = Math.floor(rec.tokens);
+  return rec;
+}
+
+async function addTokens(guildId, userId, amount = 1) {
+  if (!guildId || !userId) return 0;
+  const num = Number(amount) || 0;
+  if (num <= 0) return getBalance(guildId, userId);
+  const rec = ensureRecord(guildId, userId);
+  rec.tokens += num;
+  await saveStore();
+  return rec.tokens;
+}
+
+function getBalance(guildId, userId) {
+  if (!guildId || !userId) return 0;
+  const rec = ensureRecord(guildId, userId);
+  return rec.tokens;
+}
+
+module.exports = {
+  addTokens,
+  getBalance,
+};


### PR DESCRIPTION
## Summary
- add a bot owner only /givejudgement slash command that grants judgement tokens and confirms the new balance
- persist judgement token balances in a dedicated store for reuse
- document the new owner command in the help menu

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d77aa8c8588331a5515c08e79026a2