### PR TITLE
Display judgement balances in inventory

### DIFF
--- a/src/commands/inventory.js
+++ b/src/commands/inventory.js
@@ -1,8 +1,23 @@
 const { SlashCommandBuilder } = require('discord.js');
 const tokenStore = require('../utils/messageTokenStore');
+const judgementStore = require('../utils/judgementStore');
 const smiteConfigStore = require('../utils/smiteConfigStore');
 
 const BAG_LABEL = 'Smite';
+const JUDGEMENT_LABEL = 'Judgement';
+
+function formatCurrencyProgress(label, progress = {}) {
+  const tokens = Number.isFinite(progress.tokens) ? Math.max(0, Math.floor(progress.tokens)) : 0;
+  const messagesUntilNextRaw = Number.isFinite(progress.messagesUntilNext)
+    ? Math.max(0, Math.floor(progress.messagesUntilNext))
+    : 0;
+  const plural = tokens === 1 ? '' : 's';
+  const baseLine = `${label}: ${tokens} ${label}${plural}.`;
+  const nextLine = messagesUntilNextRaw > 0
+    ? `Next ${label} in ${messagesUntilNextRaw} message${messagesUntilNextRaw === 1 ? '' : 's'}.`
+    : `You're due for a ${label} on your next message!`;
+  return `${baseLine} ${nextLine}`;
+}
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -16,20 +31,18 @@ module.exports = {
 
     await interaction.deferReply({ ephemeral: true });
 
-    const { tokens, messagesUntilNext } = tokenStore.getProgress(interaction.guildId, interaction.user.id);
-    const plural = tokens === 1 ? '' : 's';
-    const baseLine = `You have ${tokens} ${BAG_LABEL}${plural}.`;
+    const smiteProgress = tokenStore.getProgress(interaction.guildId, interaction.user.id);
+    const judgementProgress = judgementStore.getProgress(interaction.guildId, interaction.user.id);
 
-    const nextLine = messagesUntilNext > 0
-      ? `Next ${BAG_LABEL} in ${messagesUntilNext} message${messagesUntilNext === 1 ? '' : 's'}.`
-      : `You're due for a ${BAG_LABEL} on your next message!`;
+    const smiteLine = formatCurrencyProgress(BAG_LABEL, smiteProgress);
+    const judgementLine = formatCurrencyProgress(JUDGEMENT_LABEL, judgementProgress);
 
     const smiteEnabled = smiteConfigStore.isEnabled(interaction.guildId);
     const statusLine = smiteEnabled
       ? 'Smite rewards are currently enabled on this server.'
       : 'Smite rewards are currently disabled on this server.';
 
-    const response = `${baseLine} ${nextLine} ${statusLine}`.slice(0, 1900);
+    const response = [smiteLine, judgementLine, statusLine].join('\n').slice(0, 1900);
     await interaction.editReply({ content: response });
   },
 };

--- a/src/utils/judgementStore.js
+++ b/src/utils/judgementStore.js
@@ -1,0 +1,142 @@
+const fs = require('fs');
+const { ensureFileSync, resolveDataPath, writeJson } = require('./dataDir');
+
+const STORE_FILE = resolveDataPath('judgement_tokens.json');
+const AWARD_THRESHOLD = 200;
+
+let cache = null;
+
+function ensureStoreFile() {
+  try {
+    ensureFileSync('judgement_tokens.json', { guilds: {} });
+  } catch (err) {
+    console.error('Failed to initialise judgement token store', err);
+  }
+}
+
+function loadStore() {
+  if (cache) return cache;
+  ensureStoreFile();
+  try {
+    const raw = fs.readFileSync(STORE_FILE, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') {
+      cache = { guilds: {} };
+    } else {
+      if (!parsed.guilds || typeof parsed.guilds !== 'object') parsed.guilds = {};
+      cache = parsed;
+    }
+  } catch (err) {
+    cache = { guilds: {} };
+  }
+  return cache;
+}
+
+async function saveStore() {
+  ensureStoreFile();
+  const safe = cache && typeof cache === 'object' ? cache : { guilds: {} };
+  if (!safe.guilds || typeof safe.guilds !== 'object') safe.guilds = {};
+  await writeJson('judgement_tokens.json', safe);
+}
+
+function ensureRecord(guildId, userId) {
+  const store = loadStore();
+  if (!store.guilds[guildId] || typeof store.guilds[guildId] !== 'object') {
+    store.guilds[guildId] = { users: {} };
+  }
+  const guild = store.guilds[guildId];
+  if (!guild.users || typeof guild.users !== 'object') guild.users = {};
+  if (!guild.users[userId] || typeof guild.users[userId] !== 'object') {
+    guild.users[userId] = {
+      totalMessages: 0,
+      progress: 0,
+      tokens: 0,
+    };
+  }
+  const rec = guild.users[userId];
+  if (!Number.isFinite(rec.totalMessages)) rec.totalMessages = 0;
+  if (!Number.isFinite(rec.progress) || rec.progress < 0) rec.progress = 0;
+  if (!Number.isFinite(rec.tokens) || rec.tokens < 0) rec.tokens = 0;
+  rec.totalMessages = Math.floor(rec.totalMessages);
+  rec.progress = Math.floor(rec.progress);
+  rec.tokens = Math.floor(rec.tokens);
+  if (rec.progress >= AWARD_THRESHOLD) {
+    const extra = Math.floor(rec.progress / AWARD_THRESHOLD);
+    rec.progress -= extra * AWARD_THRESHOLD;
+    rec.tokens += extra;
+  }
+  return rec;
+}
+
+async function incrementMessage(guildId, userId) {
+  if (!guildId || !userId) return null;
+  const rec = ensureRecord(guildId, userId);
+  rec.totalMessages += 1;
+  rec.progress += 1;
+  let awarded = 0;
+  while (rec.progress >= AWARD_THRESHOLD) {
+    rec.progress -= AWARD_THRESHOLD;
+    rec.tokens += 1;
+    awarded += 1;
+  }
+  await saveStore();
+  return {
+    awarded,
+    tokens: rec.tokens,
+    totalMessages: rec.totalMessages,
+    progress: rec.progress,
+    messagesUntilNext: AWARD_THRESHOLD - rec.progress,
+  };
+}
+
+async function consumeToken(guildId, userId) {
+  if (!guildId || !userId) return false;
+  const rec = ensureRecord(guildId, userId);
+  if (rec.tokens <= 0) return false;
+  rec.tokens -= 1;
+  await saveStore();
+  return true;
+}
+
+async function addTokens(guildId, userId, amount = 1) {
+  if (!guildId || !userId) return 0;
+  const num = Number(amount) || 0;
+  if (num <= 0) return getBalance(guildId, userId);
+  const rec = ensureRecord(guildId, userId);
+  rec.tokens += num;
+  await saveStore();
+  return rec.tokens;
+}
+
+function getBalance(guildId, userId) {
+  if (!guildId || !userId) return 0;
+  const rec = ensureRecord(guildId, userId);
+  return rec.tokens;
+}
+
+function getProgress(guildId, userId) {
+  if (!guildId || !userId) {
+    return {
+      totalMessages: 0,
+      tokens: 0,
+      progress: 0,
+      messagesUntilNext: AWARD_THRESHOLD,
+    };
+  }
+  const rec = ensureRecord(guildId, userId);
+  return {
+    totalMessages: rec.totalMessages,
+    tokens: rec.tokens,
+    progress: rec.progress,
+    messagesUntilNext: AWARD_THRESHOLD - rec.progress,
+  };
+}
+
+module.exports = {
+  AWARD_THRESHOLD,
+  incrementMessage,
+  consumeToken,
+  addTokens,
+  getBalance,
+  getProgress,
+};

--- a/tests/inventory.test.js
+++ b/tests/inventory.test.js
@@ -1,0 +1,50 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const inventory = require('../src/commands/inventory');
+const tokenStore = require('../src/utils/messageTokenStore');
+const judgementStore = require('../src/utils/judgementStore');
+const smiteConfigStore = require('../src/utils/smiteConfigStore');
+
+function createInteraction() {
+  let reply;
+  return {
+    inGuild: () => true,
+    guildId: 'guild',
+    user: { id: 'user' },
+    deferReply: () => Promise.resolve(),
+    editReply: (data) => {
+      reply = data;
+      return Promise.resolve(data);
+    },
+    getReply: () => reply,
+  };
+}
+
+test('inventory lists both smite and judgement balances', async () => {
+  const originalSmiteProgress = tokenStore.getProgress;
+  const originalJudgementProgress = judgementStore.getProgress;
+  const originalIsEnabled = smiteConfigStore.isEnabled;
+
+  tokenStore.getProgress = () => ({ tokens: 3, messagesUntilNext: 42 });
+  judgementStore.getProgress = () => ({ tokens: 1, messagesUntilNext: 0 });
+  smiteConfigStore.isEnabled = () => true;
+
+  try {
+    const interaction = createInteraction();
+    await inventory.execute(interaction);
+
+    const reply = interaction.getReply();
+    assert(reply, 'expected inventory command to edit the reply');
+
+    const content = reply.content;
+    assert.match(content, /Smite: 3 Smites\./);
+    assert.match(content, /Next Smite in 42 messages?\./);
+    assert.match(content, /Judgement: 1 Judgement\./);
+    assert.match(content, /You're due for a Judgement on your next message!/);
+  } finally {
+    tokenStore.getProgress = originalSmiteProgress;
+    judgementStore.getProgress = originalJudgementProgress;
+    smiteConfigStore.isEnabled = originalIsEnabled;
+  }
+});


### PR DESCRIPTION
## Summary
- add a judgement token store alongside the existing smite token tracking
- update the /inventory command to show both smite and judgement balances plus next award timing
- cover the combined output with a dedicated inventory command test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d77aa76c808331a7b3eafeb191d854