### PR TITLE
feat: add configurable analysis persona command

### DIFF
--- a/src/commands/analysis.js
+++ b/src/commands/analysis.js
@@ -1,0 +1,247 @@
+const { SlashCommandBuilder, ChannelType } = require('discord.js');
+const { createFieldEmbeds } = require('../utils/embedFields');
+const {
+  getPersona,
+  consumeJudgementToken,
+  refundJudgementToken,
+} = require('../utils/analysisConfigStore');
+
+const OPENAI_API_KEY = process.env.OPENAI_ANALYSIS_KEY || process.env.OPENAI_API_KEY || process.env.OPENAI_API;
+const OPENAI_ANALYSIS_MODEL = process.env.ANALYSIS_MODEL || process.env.OPENAI_ANALYSIS_MODEL || 'gpt-4o-mini';
+
+const MAX_FETCH_MESSAGES = 1000;
+const MAX_TRANSCRIPT_CHARS = 16000;
+const DEFAULT_PERSONA = 'You are the Dusscord analysis persona. Provide accurate, structured insights about conversations without inventing facts.';
+
+const fetchApi = (...args) => {
+  if (typeof globalThis.fetch === 'function') {
+    return globalThis.fetch(...args);
+  }
+  return import('node-fetch').then(({ default: fetch }) => fetch(...args));
+};
+
+function buildAnalysisSections(text) {
+  if (!text) return [];
+  const lines = String(text).split(/\r?\n/);
+  const sections = [];
+  let currentName = null;
+  let buffer = [];
+
+  const flush = () => {
+    if (!currentName) return;
+    const value = buffer.join('\n').trim();
+    if (value) {
+      sections.push({ name: currentName, value });
+    }
+    buffer = [];
+  };
+
+  for (const rawLine of lines) {
+    const line = rawLine ?? '';
+    const hashHeading = line.match(/^\s*#+\s*(.+)$/);
+    if (hashHeading) {
+      flush();
+      currentName = hashHeading[1].trim() || 'Analysis';
+      continue;
+    }
+    const colonHeading = line.match(/^\s*([^:#]{2,}):\s*$/);
+    if (colonHeading) {
+      flush();
+      currentName = colonHeading[1].trim() || 'Analysis';
+      continue;
+    }
+    if (!currentName) currentName = 'Analysis';
+    buffer.push(line);
+  }
+
+  flush();
+  if (!sections.length) {
+    const fallback = String(text).trim();
+    if (fallback) return [{ name: 'Analysis', value: fallback }];
+  }
+  return sections;
+}
+
+function sanitizeContent(input) {
+  if (!input) return '';
+  return String(input)
+    .replace(/<@!?(\d+)>/g, '[@$1]')
+    .replace(/<@&(\d+)>/g, '[@role:$1]')
+    .replace(/<#(\d+)>/g, '[#channel:$1]');
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('analysis')
+    .setDescription('Analyze recent channel messages with the configured analysis persona')
+    .addIntegerOption((opt) =>
+      opt
+        .setName('count')
+        .setDescription('How many recent messages to analyze (max 1000)')
+        .setRequired(false)
+        .setMinValue(1)
+        .setMaxValue(MAX_FETCH_MESSAGES)
+    ),
+
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ content: 'Use this command in a server channel.', ephemeral: true });
+    }
+
+    const channel = interaction.channel;
+    if (!channel || ![
+      ChannelType.GuildText,
+      ChannelType.PublicThread,
+      ChannelType.PrivateThread,
+      ChannelType.GuildAnnouncement,
+    ].includes(channel.type)) {
+      return interaction.reply({ content: 'This command can only run in a text channel or thread.', ephemeral: true });
+    }
+
+    try {
+      await interaction.deferReply();
+    } catch (e) {
+      const code = e?.code || e?.status;
+      const msg = (e?.message || '').toLowerCase();
+      if (code === 40060 || code === 10062 || msg.includes('already been acknowledged') || msg.includes('unknown interaction')) {
+        return;
+      }
+      throw e;
+    }
+
+    if (!OPENAI_API_KEY) {
+      return interaction.editReply('OpenAI API key not configured. Set OPENAI_API_KEY in your environment.');
+    }
+
+    const requested = interaction.options.getInteger('count') ?? 150;
+    const target = Math.min(MAX_FETCH_MESSAGES, Math.max(1, requested));
+
+    let collected = [];
+    let before;
+    try {
+      while (collected.length < target) {
+        const limit = Math.min(100, target - collected.length);
+        const batch = await channel.messages.fetch({ limit, ...(before ? { before } : {}) });
+        if (!batch || batch.size === 0) break;
+        const arr = [...batch.values()];
+        collected.push(...arr);
+        const oldest = arr.reduce((acc, m) => (!acc || m.createdTimestamp < acc.createdTimestamp ? m : acc), null);
+        before = oldest?.id;
+        if (!before) break;
+      }
+    } catch (err) {
+      return interaction.editReply(`Could not fetch recent messages: ${err.message}`);
+    }
+
+    if (!collected.length) {
+      return interaction.editReply('No recent messages found to analyze.');
+    }
+
+    const ordered = collected.sort((a, b) => a.createdTimestamp - b.createdTimestamp);
+
+    const lines = [];
+    let totalChars = 0;
+    let truncated = false;
+    for (const m of ordered) {
+      const name = m.member?.displayName || m.author?.username || 'Unknown';
+      const author = m.author?.bot ? `${name} [bot]` : name;
+      const content = sanitizeContent(m.content || '');
+      const attachments = m.attachments?.size
+        ? ` [attachments: ${[...m.attachments.values()].map((a) => a.name).filter(Boolean).join(', ')}]`
+        : '';
+      const line = content.trim()
+        ? `${author}: ${content}${attachments}`
+        : attachments
+        ? `${author}:${attachments}`
+        : '';
+      if (!line) continue;
+      if (totalChars + line.length + 1 > MAX_TRANSCRIPT_CHARS) {
+        truncated = true;
+        break;
+      }
+      lines.push(line);
+      totalChars += line.length + 1;
+    }
+
+    if (!lines.length) {
+      return interaction.editReply('Recent messages did not contain analyzable text.');
+    }
+
+    const transcript = lines.join('\n');
+    const persona = getPersona(interaction.guildId) || DEFAULT_PERSONA;
+
+    let tokenSpent = false;
+    try {
+      const consumed = await consumeJudgementToken(interaction.guildId, interaction.user.id);
+      if (!consumed) {
+        return interaction.editReply('You need a judgement token to run an analysis. Earn or request one before retrying.');
+      }
+      tokenSpent = true;
+
+      const prompt = `Provide a structured analysis of the following Discord conversation. Highlight conflicts, agreements, risks, and recommended next steps. Reference speakers by their display names. Transcript (oldest to newest):\n\n${transcript}`;
+
+      const response = await fetchApi('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${OPENAI_API_KEY}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: OPENAI_ANALYSIS_MODEL,
+          messages: [
+            { role: 'system', content: persona },
+            { role: 'user', content: prompt },
+          ],
+          temperature: 0.3,
+        }),
+      });
+
+      const text = await response.text();
+      if (!response.ok) {
+        let message = text;
+        try {
+          const parsed = JSON.parse(text);
+          message = parsed?.error?.message || message;
+        } catch (_) {}
+        throw new Error(message || 'Failed to generate analysis.');
+      }
+
+      let out;
+      try {
+        out = JSON.parse(text)?.choices?.[0]?.message?.content?.trim();
+      } catch (_) {
+        throw new Error('Invalid response from analysis provider.');
+      }
+      if (!out) {
+        throw new Error('No analysis returned.');
+      }
+
+      const sections = buildAnalysisSections(out);
+      const descriptionParts = [`Analyzed ${lines.length} messages.`];
+      if (truncated) {
+        descriptionParts.push(`Transcript truncated to ${MAX_TRANSCRIPT_CHARS} characters.`);
+      }
+      const embeds = createFieldEmbeds({
+        title: 'Conversation Analysis',
+        sections: sections.length ? sections : [{ name: 'Analysis', value: out }],
+        user: interaction.user,
+        description: descriptionParts.join(' '),
+      });
+
+      if (!embeds.length) {
+        return interaction.editReply(out);
+      }
+
+      return interaction.editReply({ embeds });
+    } catch (err) {
+      if (tokenSpent) {
+        try {
+          await refundJudgementToken(interaction.guildId, interaction.user.id);
+        } catch (refundErr) {
+          console.error('Failed to refund judgement token after analysis error', refundErr);
+        }
+      }
+      return interaction.editReply(`Analysis failed: ${err.message}`);
+    }
+  },
+};

--- a/src/commands/analysisconfig.js
+++ b/src/commands/analysisconfig.js
@@ -1,0 +1,94 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { isOwner } = require('../utils/ownerIds');
+const {
+  MAX_PERSONA_LENGTH,
+  getPersona,
+  setPersona,
+  clearPersona,
+} = require('../utils/analysisConfigStore');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('analysisconfig')
+    .setDescription('Owner-only: manage the analysis persona for this guild')
+    .addSubcommand((sub) =>
+      sub
+        .setName('set')
+        .setDescription('Set the analysis persona text used for AI analysis')
+        .addStringOption((opt) =>
+          opt
+            .setName('persona')
+            .setDescription('Persona/system prompt text (max 2000 characters)')
+            .setRequired(true)
+        )
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('show')
+        .setDescription('Show the currently configured analysis persona')
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName('clear')
+        .setDescription('Clear the saved analysis persona and use the default')
+    ),
+
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ content: 'Use this command inside a server.', ephemeral: true });
+    }
+
+    if (!isOwner(interaction.user.id)) {
+      return interaction.reply({ content: 'This command is restricted to bot owners.', ephemeral: true });
+    }
+
+    const sub = interaction.options.getSubcommand();
+
+    if (sub === 'set') {
+      const persona = interaction.options.getString('persona', true);
+      try {
+        const saved = await setPersona(interaction.guildId, persona);
+        return interaction.reply({
+          content: `Analysis persona updated (length: ${saved.length}/${MAX_PERSONA_LENGTH}).`,
+          ephemeral: true,
+        });
+      } catch (err) {
+        return interaction.reply({
+          content: `Could not update persona: ${err.message}`,
+          ephemeral: true,
+        });
+      }
+    }
+
+    if (sub === 'show') {
+      const persona = getPersona(interaction.guildId);
+      if (!persona) {
+        return interaction.reply({
+          content: 'No custom persona configured. The default system prompt will be used.',
+          ephemeral: true,
+        });
+      }
+      const preview = persona.length > 1900 ? `${persona.slice(0, 1900)}…` : persona;
+      return interaction.reply({
+        content: `**Current analysis persona:**\n${preview}`,
+        ephemeral: true,
+      });
+    }
+
+    if (sub === 'clear') {
+      const removed = await clearPersona(interaction.guildId);
+      if (removed) {
+        return interaction.reply({
+          content: 'Analysis persona cleared. The default system prompt will be used.',
+          ephemeral: true,
+        });
+      }
+      return interaction.reply({
+        content: 'There was no custom persona configured.',
+        ephemeral: true,
+      });
+    }
+
+    return interaction.reply({ content: 'Unknown subcommand.', ephemeral: true });
+  },
+};

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -59,6 +59,7 @@ const categories = {
   'AI & Media Tools': [
     { cmd: '/chat', desc: 'Chat with GPT with selectable personas and context size', perm: null },
     { cmd: '/summarize', desc: 'Summarize recent channel messages into bullets and a paragraph', perm: null },
+    { cmd: '/analysis', desc: 'Generate a persona-driven analysis of recent messages (uses judgement tokens)', perm: null },
     { cmd: '/transcribe', desc: 'Transcribe an attached audio file using Whisper', perm: null },
     { cmd: '/removebg', desc: 'Remove an image background via remove.bg', perm: null },
   ],
@@ -72,6 +73,7 @@ const categories = {
     { cmd: '/dmdiag test/role', desc: 'DM diagnostics for a member or role', perm: 'Bot Owner' },
     { cmd: '/wraith start/stop', desc: 'Create a private spam channel and isolate a member', perm: 'Bot Owner' },
     { cmd: '/securitylog set/mode/clear/toggle/show', desc: 'Configure security log delivery and enablement', perm: 'Bot Owner' },
+    { cmd: '/analysisconfig set/show/clear', desc: 'Manage the analysis persona for guild transcripts', perm: 'Bot Owner' },
   ],
 };
 

--- a/src/utils/analysisConfigStore.js
+++ b/src/utils/analysisConfigStore.js
@@ -1,0 +1,144 @@
+const { ensureFileSync, readJsonSync, writeJson } = require('./dataDir');
+
+const STORE_FILE = 'analysis_config.json';
+const MAX_PERSONA_LENGTH = 2000;
+
+let cache = null;
+
+function ensureStore() {
+  ensureFileSync(STORE_FILE, { guilds: {} });
+}
+
+function loadStore() {
+  if (cache) return cache;
+  ensureStore();
+  try {
+    const data = readJsonSync(STORE_FILE, { guilds: {} });
+    if (!data || typeof data !== 'object') {
+      cache = { guilds: {} };
+    } else {
+      if (!data.guilds || typeof data.guilds !== 'object') data.guilds = {};
+      cache = data;
+    }
+  } catch (err) {
+    console.error('Failed to load analysis config store', err);
+    cache = { guilds: {} };
+  }
+  return cache;
+}
+
+async function saveStore() {
+  const store = loadStore();
+  const safe = store && typeof store === 'object' ? store : { guilds: {} };
+  if (!safe.guilds || typeof safe.guilds !== 'object') safe.guilds = {};
+  await writeJson(STORE_FILE, safe);
+}
+
+function ensureGuildRecord(guildId) {
+  const store = loadStore();
+  if (!guildId) return { persona: null, updatedAt: null, judgement: { users: {} } };
+  if (!store.guilds[guildId] || typeof store.guilds[guildId] !== 'object') {
+    store.guilds[guildId] = { persona: null, updatedAt: null, judgement: { users: {} } };
+  }
+  const guild = store.guilds[guildId];
+  if (!guild.judgement || typeof guild.judgement !== 'object') guild.judgement = { users: {} };
+  if (!guild.judgement.users || typeof guild.judgement.users !== 'object') guild.judgement.users = {};
+  return guild;
+}
+
+function ensureUserRecord(guildId, userId) {
+  if (!guildId || !userId) return { tokens: 0 };
+  const guild = ensureGuildRecord(guildId);
+  if (!guild.judgement.users[userId] || typeof guild.judgement.users[userId] !== 'object') {
+    guild.judgement.users[userId] = { tokens: 0, updatedAt: null };
+  }
+  const user = guild.judgement.users[userId];
+  if (!Number.isFinite(user.tokens) || user.tokens < 0) user.tokens = 0;
+  return user;
+}
+
+function getPersona(guildId) {
+  if (!guildId) return null;
+  const guild = ensureGuildRecord(guildId);
+  const persona = guild.persona;
+  if (typeof persona === 'string' && persona.trim()) {
+    return persona;
+  }
+  return null;
+}
+
+async function setPersona(guildId, text) {
+  if (!guildId) throw new Error('Guild ID is required.');
+  const raw = typeof text === 'string' ? text.trim() : '';
+  if (!raw) throw new Error('Persona text cannot be empty.');
+  if (raw.length > MAX_PERSONA_LENGTH) {
+    throw new Error(`Persona text must be at most ${MAX_PERSONA_LENGTH} characters.`);
+  }
+  const guild = ensureGuildRecord(guildId);
+  guild.persona = raw;
+  guild.updatedAt = new Date().toISOString();
+  await saveStore();
+  return guild.persona;
+}
+
+async function clearPersona(guildId) {
+  if (!guildId) return false;
+  const guild = ensureGuildRecord(guildId);
+  if (!guild.persona) return false;
+  guild.persona = null;
+  guild.updatedAt = new Date().toISOString();
+  await saveStore();
+  return true;
+}
+
+function getJudgementBalance(guildId, userId) {
+  if (!guildId || !userId) return 0;
+  const record = ensureUserRecord(guildId, userId);
+  return record.tokens;
+}
+
+async function addJudgementTokens(guildId, userId, amount = 1) {
+  if (!guildId || !userId) return 0;
+  const value = Number(amount) || 0;
+  if (value <= 0) return getJudgementBalance(guildId, userId);
+  const record = ensureUserRecord(guildId, userId);
+  record.tokens += value;
+  record.updatedAt = new Date().toISOString();
+  await saveStore();
+  return record.tokens;
+}
+
+async function consumeJudgementToken(guildId, userId) {
+  if (!guildId || !userId) return false;
+  const record = ensureUserRecord(guildId, userId);
+  if (record.tokens <= 0) return false;
+  record.tokens -= 1;
+  record.updatedAt = new Date().toISOString();
+  await saveStore();
+  return true;
+}
+
+async function refundJudgementToken(guildId, userId) {
+  if (!guildId || !userId) return 0;
+  const record = ensureUserRecord(guildId, userId);
+  record.tokens += 1;
+  record.updatedAt = new Date().toISOString();
+  await saveStore();
+  return record.tokens;
+}
+
+function clearCache() {
+  cache = null;
+}
+
+module.exports = {
+  MAX_PERSONA_LENGTH,
+  getPersona,
+  setPersona,
+  clearPersona,
+  getJudgementBalance,
+  addJudgementTokens,
+  consumeJudgementToken,
+  refundJudgementToken,
+  clearCache,
+};

--- a/tests/analysisCommand.test.js
+++ b/tests/analysisCommand.test.js
@@ -1,0 +1,168 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { ChannelType } = require('discord.js');
+const path = require('node:path');
+
+const storeModule = require('../src/utils/analysisConfigStore');
+const commandPath = path.resolve(__dirname, '../src/commands/analysis.js');
+
+function reimportCommand() {
+  delete require.cache[commandPath];
+  return require(commandPath);
+}
+
+function makeMessage(id, content, timestamp, authorName = 'Alpha') {
+  return {
+    id,
+    content,
+    createdTimestamp: timestamp,
+    member: { displayName: authorName },
+    author: { username: authorName, bot: false },
+    attachments: new Map(),
+  };
+}
+
+function makeInteraction(channel) {
+  let reply;
+  return {
+    inGuild: () => true,
+    guildId: 'guild1',
+    user: {
+      id: 'user1',
+      username: 'Analyst',
+      displayAvatarURL: () => null,
+    },
+    channel,
+    options: {
+      getInteger: () => null,
+    },
+    deferReply: () => Promise.resolve(),
+    editReply: (data) => {
+      reply = data;
+      return Promise.resolve(data);
+    },
+    reply: (data) => {
+      reply = data;
+      return Promise.resolve(data);
+    },
+    getReply: () => reply,
+  };
+}
+
+test('analysis command consumes a token and sends persona to API', async () => {
+  const now = Date.now();
+  const messages = [
+    makeMessage('1', 'First message', now - 3000, 'Alpha'),
+    makeMessage('2', 'Second message', now - 2000, 'Beta'),
+  ];
+
+  const channel = {
+    type: ChannelType.GuildText,
+    messages: {
+      fetch: async ({ before }) => {
+        if (before) return new Map();
+        return new Map(messages.map((m) => [m.id, m]));
+      },
+    },
+  };
+
+  const consumeMock = test.mock.method(storeModule, 'consumeJudgementToken', async () => true);
+  const refundMock = test.mock.method(storeModule, 'refundJudgementToken', async () => {});
+  const personaMock = test.mock.method(storeModule, 'getPersona', () => 'Custom Persona');
+
+  const originalEnv = process.env.OPENAI_API_KEY;
+  process.env.OPENAI_API_KEY = 'test-key';
+
+  const fetchCalls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    fetchCalls.push({ url, init });
+    return {
+      ok: true,
+      text: async () => JSON.stringify({
+        choices: [
+          {
+            message: {
+              content: 'Overview:\nEverything looks good.',
+            },
+          },
+        ],
+      }),
+    };
+  };
+
+  try {
+    const command = reimportCommand();
+    const interaction = makeInteraction(channel);
+    await command.execute(interaction);
+
+    assert.equal(consumeMock.mock.callCount(), 1);
+    assert.equal(refundMock.mock.callCount(), 0);
+    assert.equal(fetchCalls.length, 1);
+    const body = JSON.parse(fetchCalls[0].init.body);
+    assert.equal(body.messages[0].content, 'Custom Persona');
+    assert.match(body.messages[1].content, /First message/);
+
+    const reply = interaction.getReply();
+    assert.ok(reply.embeds?.length); 
+    assert.equal(reply.embeds[0].data.title, 'Conversation Analysis');
+  } finally {
+    consumeMock.mock.restore();
+    refundMock.mock.restore();
+    personaMock.mock.restore();
+    globalThis.fetch = originalFetch;
+    if (originalEnv === undefined) {
+      delete process.env.OPENAI_API_KEY;
+    } else {
+      process.env.OPENAI_API_KEY = originalEnv;
+    }
+    delete require.cache[commandPath];
+  }
+});
+
+test('analysis command refunds token on API failure', async () => {
+  const now = Date.now();
+  const channel = {
+    type: ChannelType.GuildText,
+    messages: {
+      fetch: async () => new Map([
+        ['1', makeMessage('1', 'Only message', now - 1000, 'Gamma')],
+      ]),
+    },
+  };
+
+  const consumeMock = test.mock.method(storeModule, 'consumeJudgementToken', async () => true);
+  const refundMock = test.mock.method(storeModule, 'refundJudgementToken', async () => {});
+  const personaMock = test.mock.method(storeModule, 'getPersona', () => null);
+
+  const originalEnv = process.env.OPENAI_API_KEY;
+  process.env.OPENAI_API_KEY = 'test-key';
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({
+    ok: false,
+    text: async () => JSON.stringify({ error: { message: 'Model busy' } }),
+  });
+
+  try {
+    const command = reimportCommand();
+    const interaction = makeInteraction(channel);
+    await command.execute(interaction);
+
+    assert.equal(consumeMock.mock.callCount(), 1);
+    assert.equal(refundMock.mock.callCount(), 1);
+    const reply = interaction.getReply();
+    assert.equal(reply, 'Analysis failed: Model busy');
+  } finally {
+    consumeMock.mock.restore();
+    refundMock.mock.restore();
+    personaMock.mock.restore();
+    globalThis.fetch = originalFetch;
+    if (originalEnv === undefined) {
+      delete process.env.OPENAI_API_KEY;
+    } else {
+      process.env.OPENAI_API_KEY = originalEnv;
+    }
+    delete require.cache[commandPath];
+  }
+});

--- a/tests/analysisConfigStore.test.js
+++ b/tests/analysisConfigStore.test.js
@@ -1,0 +1,51 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const modulePath = require.resolve('../src/utils/analysisConfigStore');
+
+async function withTempStore(fn) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'analysis-config-'));
+  delete require.cache[modulePath];
+  process.env.DUSSCORD_DATA_DIR = tmpDir;
+  const store = require(modulePath);
+  try {
+    await fn(store, tmpDir);
+  } finally {
+    delete require.cache[modulePath];
+    delete process.env.DUSSCORD_DATA_DIR;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+test('analysis persona set/show/clear cycle persists to disk', async () => {
+  await withTempStore(async (store, dir) => {
+    assert.equal(store.getPersona('guild'), null);
+    await assert.rejects(() => store.setPersona('guild', '   '), /cannot be empty/i);
+    const saved = await store.setPersona('guild', ' Investigator persona ');
+    assert.equal(saved, 'Investigator persona');
+    assert.equal(store.getPersona('guild'), 'Investigator persona');
+    const file = path.join(dir, 'analysis_config.json');
+    assert.ok(fs.existsSync(file));
+    const raw = JSON.parse(fs.readFileSync(file, 'utf8'));
+    assert.equal(raw.guilds.guild.persona, 'Investigator persona');
+    const cleared = await store.clearPersona('guild');
+    assert.equal(cleared, true);
+    assert.equal(store.getPersona('guild'), null);
+  });
+});
+
+test('judgement tokens can be added, consumed, and refunded', async () => {
+  await withTempStore(async (store) => {
+    assert.equal(store.getJudgementBalance('g', 'u'), 0);
+    assert.equal(await store.consumeJudgementToken('g', 'u'), false);
+    await store.addJudgementTokens('g', 'u', 2);
+    assert.equal(store.getJudgementBalance('g', 'u'), 2);
+    assert.equal(await store.consumeJudgementToken('g', 'u'), true);
+    assert.equal(store.getJudgementBalance('g', 'u'), 1);
+    await store.refundJudgementToken('g', 'u');
+    assert.equal(store.getJudgementBalance('g', 'u'), 2);
+  });
+});


### PR DESCRIPTION
## Summary
- add an analysis config store to persist personas and judgement tokens per guild
- implement /analysis and /analysisconfig commands wired to the OpenAI API and persona management
- surface the new command paths in the help menu and cover persona/token flows with tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d77a9fbafc83318f7fd84067c2d245