### PR TITLE
Add /analysis command powered by Judgement currency

### DIFF
--- a/src/commands/analysis.js
+++ b/src/commands/analysis.js
@@ -1,0 +1,169 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const judgementStore = require('../utils/judgementStore');
+const messageLogStore = require('../utils/userMessageLogStore');
+
+const fetch = (...args) => import('node-fetch').then(({ default: fetchImpl }) => fetchImpl(...args));
+
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY || process.env.OPENAI_API;
+const OPENAI_CHAT_MODEL = process.env.ANALYSIS_MODEL || process.env.CHAT_MODEL || 'gpt-4o-mini';
+
+const DEFAULT_PERSONA = (process.env.ANALYSIS_PERSONA_PROMPT || '').trim() || [
+  'You are a private analytical assistant configured by the bot owner to review community members.',
+  'Analyse the supplied Discord messages for tone, behaviour patterns, rule compliance, and wellbeing concerns.',
+  'Respond in JSON with keys "summary", "strengths", "risks", and "recommendations". Each value must be a short markdown string (<800 characters).',
+  'Do not include any other keys or explanatory text.',
+].join(' ');
+
+function formatMessages(logs, targetCount) {
+  if (!Array.isArray(logs) || !logs.length) {
+    return { text: 'No recent messages.', usedCount: 0 };
+  }
+  const lines = [];
+  let consumed = 0;
+  for (let i = logs.length - 1; i >= 0; i -= 1) {
+    if (lines.length >= targetCount) break;
+    const entry = logs[i];
+    const ts = Number.isFinite(entry?.createdTimestamp)
+      ? new Date(entry.createdTimestamp).toISOString()
+      : 'unknown time';
+    const baseContent = entry?.content ? entry.content : '(no content)';
+    const snippet = baseContent.length > 350 ? `${baseContent.slice(0, 347)}...` : baseContent;
+    consumed += snippet.length;
+    if (consumed > 150_000) break;
+    lines.push(`- [${ts}] ${snippet}`);
+  }
+  if (!lines.length) {
+    return { text: 'No recent messages.', usedCount: 0 };
+  }
+  const ordered = lines.reverse();
+  return { text: ordered.join('\n'), usedCount: ordered.length };
+}
+
+function buildEmbed(interaction, analysis, count) {
+  const embed = new EmbedBuilder()
+    .setTitle('User Analysis')
+    .setColor(0x5865f2)
+    .setDescription(`Review of ${interaction.user.tag} (${interaction.user.id})\nMessages analysed: ${count}`)
+    .setTimestamp(new Date());
+
+  const fields = [];
+  if (analysis && typeof analysis === 'object') {
+    const entries = [
+      ['Summary', analysis.summary],
+      ['Strengths', analysis.strengths],
+      ['Risks', analysis.risks],
+      ['Recommendations', analysis.recommendations],
+    ];
+    for (const [name, value] of entries) {
+      if (!value) continue;
+      const safe = String(value).slice(0, 1024) || 'No data provided.';
+      fields.push({ name, value: safe, inline: false });
+    }
+  }
+
+  if (!fields.length) {
+    const fallback = typeof analysis === 'string' ? analysis : 'No analysis generated.';
+    fields.push({ name: 'Report', value: fallback.slice(0, 1024) || 'No analysis generated.', inline: false });
+  }
+
+  embed.addFields(fields);
+  return embed;
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('analysis')
+    .setDescription('Spend a Judgement to analyse your last 1000 messages'),
+
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ content: 'Use this command inside a server.', ephemeral: true });
+    }
+
+    try { await interaction.deferReply({ ephemeral: true }); } catch (_) {}
+
+    if (!OPENAI_API_KEY) {
+      return interaction.editReply({ content: 'OpenAI API key not configured. Set OPENAI_API_KEY to enable /analysis.' });
+    }
+
+    const balance = judgementStore.getBalance(interaction.guildId, interaction.user.id);
+    if (balance <= 0) {
+      const progress = judgementStore.getProgress(interaction.guildId, interaction.user.id);
+      const remaining = progress.messagesUntilNext || judgementStore.AWARD_THRESHOLD;
+      return interaction.editReply({
+        content: `You do not have any Judgements. Send ${remaining} more message${remaining === 1 ? '' : 's'} to earn one, or ask an owner to use /givejudgement.`,
+      });
+    }
+
+    const logs = messageLogStore.getRecentMessages(interaction.guildId, interaction.user.id, 1000);
+    if (!logs.length) {
+      return interaction.editReply({ content: 'No message history recorded yet. Try again after chatting more.' });
+    }
+
+    const consumed = await judgementStore.consumeToken(interaction.guildId, interaction.user.id);
+    if (!consumed) {
+      return interaction.editReply({ content: 'You no longer have a Judgement to spend.' });
+    }
+
+    const { text: formatted, usedCount } = formatMessages(logs, 1000);
+    if (usedCount === 0) {
+      await judgementStore.addTokens(interaction.guildId, interaction.user.id, 1);
+      return interaction.editReply({ content: 'Unable to find analysable messages yet. Try again later.' });
+    }
+
+    const prompt = [
+      `Analyse the following ${usedCount} messages written by ${interaction.user.tag}.`,
+      'Identify behavioural patterns, moderation concerns, sentiment, and notable habits.',
+      'Focus strictly on the content and avoid speculation beyond the evidence provided.',
+      'Return JSON only.',
+      '',
+      formatted,
+    ].join('\n');
+
+    try {
+      const response = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${OPENAI_API_KEY}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: OPENAI_CHAT_MODEL,
+          messages: [
+            { role: 'system', content: DEFAULT_PERSONA },
+            { role: 'user', content: prompt },
+          ],
+          temperature: 0.3,
+        }),
+      });
+
+      const text = await response.text();
+      if (!response.ok) {
+        let msg = text;
+        try { msg = JSON.parse(text)?.error?.message || msg; } catch (_) {}
+        throw new Error(msg);
+      }
+
+      let analysis;
+      try {
+        const data = JSON.parse(text);
+        const out = data?.choices?.[0]?.message?.content?.trim();
+        if (!out) throw new Error('No analysis returned.');
+        try {
+          analysis = JSON.parse(out);
+        } catch (_) {
+          analysis = out;
+        }
+      } catch (err) {
+        throw err;
+      }
+
+      const embed = buildEmbed(interaction, analysis, usedCount);
+      await interaction.editReply({ embeds: [embed] });
+    } catch (err) {
+      await judgementStore.addTokens(interaction.guildId, interaction.user.id, 1);
+      const msg = err?.message || String(err);
+      await interaction.editReply({ content: `Analysis failed: ${msg}` });
+    }
+  },
+};

--- a/src/commands/givejudgement.js
+++ b/src/commands/givejudgement.js
@@ -1,0 +1,53 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { isOwner } = require('../utils/ownerIds');
+const judgementStore = require('../utils/judgementStore');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('givejudgement')
+    .setDescription('Owner: grant Judgements to a user')
+    .addUserOption(opt =>
+      opt
+        .setName('user')
+        .setDescription('Member to receive Judgements')
+        .setRequired(true)
+    )
+    .addIntegerOption(opt =>
+      opt
+        .setName('amount')
+        .setDescription('How many Judgements to grant (default 1)')
+        .setMinValue(1)
+    )
+    .addStringOption(opt =>
+      opt
+        .setName('reason')
+        .setDescription('Optional note for the recipient (max 200 characters)')
+        .setMaxLength(200)
+    ),
+
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ content: 'Use this command in a server.', ephemeral: true });
+    }
+
+    if (!isOwner(interaction.user.id)) {
+      return interaction.reply({ content: 'Only the bot owner can use this command.', ephemeral: true });
+    }
+
+    const target = interaction.options.getUser('user', true);
+    const amountInput = interaction.options.getInteger('amount');
+    const amount = Number.isFinite(amountInput) ? amountInput : 1;
+    const reason = (interaction.options.getString('reason') || '').trim();
+
+    const total = await judgementStore.addTokens(interaction.guildId, target.id, amount);
+
+    const base = `Granted ${amount} Judgement${amount === 1 ? '' : 's'} to ${target.tag}.`;
+    const balanceLine = `They now have ${total} Judgement${total === 1 ? '' : 's'}.`;
+    const reasonLine = reason ? `Reason: ${reason}` : '';
+
+    return interaction.reply({
+      content: [base, balanceLine, reasonLine].filter(Boolean).join('\n').slice(0, 1900),
+      ephemeral: true,
+    });
+  },
+};

--- a/src/commands/inventory.js
+++ b/src/commands/inventory.js
@@ -1,8 +1,10 @@
 const { SlashCommandBuilder } = require('discord.js');
 const tokenStore = require('../utils/messageTokenStore');
+const judgementStore = require('../utils/judgementStore');
 const smiteConfigStore = require('../utils/smiteConfigStore');
 
 const BAG_LABEL = 'Smite';
+const JUDGEMENT_LABEL = 'Judgement';
 
 function formatCurrencyProgress(label, progress = {}) {
   const tokens = Number.isFinite(progress.tokens) ? Math.max(0, Math.floor(progress.tokens)) : 0;
@@ -30,14 +32,20 @@ module.exports = {
     await interaction.deferReply({ ephemeral: true });
 
     const smiteProgress = tokenStore.getProgress(interaction.guildId, interaction.user.id);
+    const judgementProgress = judgementStore.getProgress(interaction.guildId, interaction.user.id);
     const smiteLine = formatCurrencyProgress(BAG_LABEL, smiteProgress);
+    const judgementLine = formatCurrencyProgress(JUDGEMENT_LABEL, judgementProgress);
 
     const smiteEnabled = smiteConfigStore.isEnabled(interaction.guildId);
     const statusLine = smiteEnabled
       ? 'Smite rewards are currently enabled on this server.'
       : 'Smite rewards are currently disabled on this server.';
 
-    const response = [smiteLine, statusLine].join('\n').slice(0, 1900);
+    const judgementHint = 'Judgements unlock /analysis. Earn one every 500 messages or via /givejudgement.';
+
+    const response = [smiteLine, judgementLine, statusLine, judgementHint]
+      .join('\n')
+      .slice(0, 1900);
     await interaction.editReply({ content: response });
   },
 };

--- a/src/events/messageCreate.judgements.js
+++ b/src/events/messageCreate.judgements.js
@@ -1,0 +1,20 @@
+const { Events } = require('discord.js');
+const judgementStore = require('../utils/judgementStore');
+const messageLogStore = require('../utils/userMessageLogStore');
+
+module.exports = {
+  name: Events.MessageCreate,
+  async execute(message) {
+    try {
+      if (!message?.guild) return;
+      if (message.author?.bot) return;
+
+      await Promise.all([
+        judgementStore.incrementMessage(message.guild.id, message.author.id),
+        messageLogStore.recordMessage(message.guild.id, message.author.id, message),
+      ]);
+    } catch (err) {
+      console.error('Failed to update judgement progress', err);
+    }
+  },
+};

--- a/src/utils/judgementStore.js
+++ b/src/utils/judgementStore.js
@@ -1,0 +1,142 @@
+const fs = require('fs');
+const { ensureFileSync, resolveDataPath, writeJson } = require('./dataDir');
+
+const STORE_FILE = resolveDataPath('judgement_tokens.json');
+const AWARD_THRESHOLD = 500;
+
+let cache = null;
+
+function ensureStoreFile() {
+  try {
+    ensureFileSync('judgement_tokens.json', { guilds: {} });
+  } catch (err) {
+    console.error('Failed to initialise judgement token store', err);
+  }
+}
+
+function loadStore() {
+  if (cache) return cache;
+  ensureStoreFile();
+  try {
+    const raw = fs.readFileSync(STORE_FILE, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') {
+      cache = { guilds: {} };
+    } else {
+      if (!parsed.guilds || typeof parsed.guilds !== 'object') parsed.guilds = {};
+      cache = parsed;
+    }
+  } catch (err) {
+    cache = { guilds: {} };
+  }
+  return cache;
+}
+
+async function saveStore() {
+  ensureStoreFile();
+  const safe = cache && typeof cache === 'object' ? cache : { guilds: {} };
+  if (!safe.guilds || typeof safe.guilds !== 'object') safe.guilds = {};
+  await writeJson('judgement_tokens.json', safe);
+}
+
+function ensureRecord(guildId, userId) {
+  const store = loadStore();
+  if (!store.guilds[guildId] || typeof store.guilds[guildId] !== 'object') {
+    store.guilds[guildId] = { users: {} };
+  }
+  const guild = store.guilds[guildId];
+  if (!guild.users || typeof guild.users !== 'object') guild.users = {};
+  if (!guild.users[userId] || typeof guild.users[userId] !== 'object') {
+    guild.users[userId] = {
+      totalMessages: 0,
+      progress: 0,
+      tokens: 0,
+    };
+  }
+  const rec = guild.users[userId];
+  if (!Number.isFinite(rec.totalMessages)) rec.totalMessages = 0;
+  if (!Number.isFinite(rec.progress) || rec.progress < 0) rec.progress = 0;
+  if (!Number.isFinite(rec.tokens) || rec.tokens < 0) rec.tokens = 0;
+  rec.totalMessages = Math.floor(rec.totalMessages);
+  rec.progress = Math.floor(rec.progress);
+  rec.tokens = Math.floor(rec.tokens);
+  if (rec.progress >= AWARD_THRESHOLD) {
+    const extra = Math.floor(rec.progress / AWARD_THRESHOLD);
+    rec.progress -= extra * AWARD_THRESHOLD;
+    rec.tokens += extra;
+  }
+  return rec;
+}
+
+async function incrementMessage(guildId, userId) {
+  if (!guildId || !userId) return null;
+  const rec = ensureRecord(guildId, userId);
+  rec.totalMessages += 1;
+  rec.progress += 1;
+  let awarded = 0;
+  while (rec.progress >= AWARD_THRESHOLD) {
+    rec.progress -= AWARD_THRESHOLD;
+    rec.tokens += 1;
+    awarded += 1;
+  }
+  await saveStore();
+  return {
+    awarded,
+    tokens: rec.tokens,
+    totalMessages: rec.totalMessages,
+    progress: rec.progress,
+    messagesUntilNext: AWARD_THRESHOLD - rec.progress,
+  };
+}
+
+async function consumeToken(guildId, userId) {
+  if (!guildId || !userId) return false;
+  const rec = ensureRecord(guildId, userId);
+  if (rec.tokens <= 0) return false;
+  rec.tokens -= 1;
+  await saveStore();
+  return true;
+}
+
+async function addTokens(guildId, userId, amount = 1) {
+  if (!guildId || !userId) return 0;
+  const num = Number(amount) || 0;
+  if (num <= 0) return getBalance(guildId, userId);
+  const rec = ensureRecord(guildId, userId);
+  rec.tokens += num;
+  await saveStore();
+  return rec.tokens;
+}
+
+function getBalance(guildId, userId) {
+  if (!guildId || !userId) return 0;
+  const rec = ensureRecord(guildId, userId);
+  return rec.tokens;
+}
+
+function getProgress(guildId, userId) {
+  if (!guildId || !userId) {
+    return {
+      totalMessages: 0,
+      tokens: 0,
+      progress: 0,
+      messagesUntilNext: AWARD_THRESHOLD,
+    };
+  }
+  const rec = ensureRecord(guildId, userId);
+  return {
+    totalMessages: rec.totalMessages,
+    tokens: rec.tokens,
+    progress: rec.progress,
+    messagesUntilNext: AWARD_THRESHOLD - rec.progress,
+  };
+}
+
+module.exports = {
+  AWARD_THRESHOLD,
+  incrementMessage,
+  consumeToken,
+  addTokens,
+  getBalance,
+  getProgress,
+};

--- a/src/utils/userMessageLogStore.js
+++ b/src/utils/userMessageLogStore.js
@@ -1,0 +1,105 @@
+const fs = require('fs');
+const { ensureFileSync, resolveDataPath, writeJson } = require('./dataDir');
+
+const STORE_FILE = resolveDataPath('user_messages.json');
+const MAX_PER_USER = 1000;
+
+let cache = null;
+
+function ensureStoreFile() {
+  try {
+    ensureFileSync('user_messages.json', { guilds: {} });
+  } catch (err) {
+    console.error('Failed to initialise user message log store', err);
+  }
+}
+
+function loadStore() {
+  if (cache) return cache;
+  ensureStoreFile();
+  try {
+    const raw = fs.readFileSync(STORE_FILE, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') {
+      cache = { guilds: {} };
+    } else {
+      if (!parsed.guilds || typeof parsed.guilds !== 'object') parsed.guilds = {};
+      cache = parsed;
+    }
+  } catch (err) {
+    cache = { guilds: {} };
+  }
+  return cache;
+}
+
+async function saveStore() {
+  ensureStoreFile();
+  const safe = cache && typeof cache === 'object' ? cache : { guilds: {} };
+  if (!safe.guilds || typeof safe.guilds !== 'object') safe.guilds = {};
+  await writeJson('user_messages.json', safe);
+}
+
+function ensureGuildUser(guildId, userId) {
+  const store = loadStore();
+  if (!store.guilds[guildId] || typeof store.guilds[guildId] !== 'object') {
+    store.guilds[guildId] = { users: {} };
+  }
+  const guild = store.guilds[guildId];
+  if (!guild.users || typeof guild.users !== 'object') guild.users = {};
+  if (!Array.isArray(guild.users[userId])) {
+    guild.users[userId] = [];
+  }
+  return guild.users[userId];
+}
+
+function sanitizeContent(content) {
+  if (!content) return '';
+  return String(content)
+    .replace(/<@!(\d+)>/g, '[@$1]')
+    .replace(/<@(\d+)>/g, '[@$1]')
+    .replace(/<@&(\d+)>/g, '[@role:$1]')
+    .replace(/<#(\d+)>/g, '[#channel:$1]');
+}
+
+async function recordMessage(guildId, userId, message) {
+  if (!guildId || !userId) return;
+  const contentRaw = message?.content || '';
+  let cleaned = sanitizeContent(contentRaw).slice(0, 1900);
+  if (!cleaned && message?.attachments?.size) {
+    const attachments = [...message.attachments.values()].slice(0, 3)
+      .map(att => att?.name || 'attachment');
+    cleaned = attachments.length
+      ? `Attachments: ${attachments.join(', ')}`
+      : '';
+  }
+  const entry = {
+    id: message?.id || null,
+    channelId: message?.channelId || null,
+    content: cleaned,
+    createdTimestamp: Number.isFinite(message?.createdTimestamp)
+      ? Number(message.createdTimestamp)
+      : Date.now(),
+  };
+
+  const list = ensureGuildUser(guildId, userId);
+  list.push(entry);
+  if (list.length > MAX_PER_USER) {
+    list.splice(0, list.length - MAX_PER_USER);
+  }
+  await saveStore();
+}
+
+function getRecentMessages(guildId, userId, limit = MAX_PER_USER) {
+  if (!guildId || !userId) return [];
+  const list = ensureGuildUser(guildId, userId);
+  if (!Array.isArray(list) || !list.length) return [];
+  const count = Math.min(MAX_PER_USER, Math.max(0, Number(limit) || 0));
+  const slice = list.slice(-count);
+  return slice.sort((a, b) => a.createdTimestamp - b.createdTimestamp);
+}
+
+module.exports = {
+  MAX_PER_USER,
+  recordMessage,
+  getRecentMessages,
+};

--- a/tests/inventory.test.js
+++ b/tests/inventory.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert/strict');
 
 const inventory = require('../src/commands/inventory');
 const tokenStore = require('../src/utils/messageTokenStore');
+const judgementStore = require('../src/utils/judgementStore');
 const smiteConfigStore = require('../src/utils/smiteConfigStore');
 
 function createInteraction() {
@@ -20,11 +21,13 @@ function createInteraction() {
   };
 }
 
-test('inventory lists smite balance and status', async () => {
+test('inventory lists smite and judgement balances with status', async () => {
   const originalSmiteProgress = tokenStore.getProgress;
+  const originalJudgementProgress = judgementStore.getProgress;
   const originalIsEnabled = smiteConfigStore.isEnabled;
 
   tokenStore.getProgress = () => ({ tokens: 3, messagesUntilNext: 42 });
+  judgementStore.getProgress = () => ({ tokens: 1, messagesUntilNext: 12 });
   smiteConfigStore.isEnabled = () => true;
 
   try {
@@ -37,9 +40,13 @@ test('inventory lists smite balance and status', async () => {
     const content = reply.content;
     assert.match(content, /Smite: 3 Smites\./);
     assert.match(content, /Next Smite in 42 messages?\./);
+    assert.match(content, /Judgement: 1 Judgement\./);
+    assert.match(content, /Next Judgement in 12 messages?\./);
     assert.match(content, /Smite rewards are currently enabled on this server\./);
+    assert.match(content, /Judgements unlock \/analysis\./);
   } finally {
     tokenStore.getProgress = originalSmiteProgress;
+    judgementStore.getProgress = originalJudgementProgress;
     smiteConfigStore.isEnabled = originalIsEnabled;
   }
 });

--- a/tests/judgementStore.test.js
+++ b/tests/judgementStore.test.js
@@ -1,0 +1,71 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const modulePath = require.resolve('../src/utils/judgementStore');
+
+async function withTempStore(fn) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'judgements-'));
+  delete require.cache[modulePath];
+  process.env.DUSSCORD_DATA_DIR = tmpDir;
+  const store = require(modulePath);
+  try {
+    await fn(store, tmpDir);
+  } finally {
+    delete require.cache[modulePath];
+    delete process.env.DUSSCORD_DATA_DIR;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+test('awards a Judgement every 500 messages', async () => {
+  await withTempStore(async store => {
+    const guildId = 'guild';
+    const userId = 'user';
+    for (let i = 0; i < store.AWARD_THRESHOLD - 1; i++) {
+      const res = await store.incrementMessage(guildId, userId);
+      assert.equal(res.awarded, 0);
+      assert.equal(res.tokens, 0);
+    }
+    const result = await store.incrementMessage(guildId, userId);
+    assert.equal(result.awarded, 1);
+    assert.equal(result.tokens, 1);
+    assert.equal(result.progress, 0);
+    assert.equal(result.messagesUntilNext, store.AWARD_THRESHOLD);
+
+    const stats = store.getProgress(guildId, userId);
+    assert.equal(stats.tokens, 1);
+    assert.equal(stats.progress, 0);
+    assert.equal(stats.messagesUntilNext, store.AWARD_THRESHOLD);
+
+    const file = path.join(process.env.DUSSCORD_DATA_DIR, 'judgement_tokens.json');
+    assert.ok(fs.existsSync(file));
+    const saved = JSON.parse(fs.readFileSync(file, 'utf8'));
+    assert.equal(saved.guilds[guildId].users[userId].tokens, 1);
+  });
+});
+
+test('consuming and refunding Judgements updates balance', async () => {
+  await withTempStore(async store => {
+    const guildId = 'guild';
+    const userId = 'user';
+
+    for (let i = 0; i < store.AWARD_THRESHOLD; i++) {
+      await store.incrementMessage(guildId, userId);
+    }
+    assert.equal(store.getBalance(guildId, userId), 1);
+
+    const spent = await store.consumeToken(guildId, userId);
+    assert.equal(spent, true);
+    assert.equal(store.getBalance(guildId, userId), 0);
+
+    const spentAgain = await store.consumeToken(guildId, userId);
+    assert.equal(spentAgain, false);
+
+    const refunded = await store.addTokens(guildId, userId, 2);
+    assert.equal(refunded, 2);
+    assert.equal(store.getBalance(guildId, userId), 2);
+  });
+});

--- a/tests/userMessageLogStore.test.js
+++ b/tests/userMessageLogStore.test.js
@@ -1,0 +1,70 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const modulePath = require.resolve('../src/utils/userMessageLogStore');
+
+async function withTempStore(fn) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'user-messages-'));
+  delete require.cache[modulePath];
+  process.env.DUSSCORD_DATA_DIR = tmpDir;
+  const store = require(modulePath);
+  try {
+    await fn(store, tmpDir);
+  } finally {
+    delete require.cache[modulePath];
+    delete process.env.DUSSCORD_DATA_DIR;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+test('records messages up to the maximum per user', async () => {
+  await withTempStore(async store => {
+    const guildId = 'guild';
+    const userId = 'user';
+    for (let i = 0; i < store.MAX_PER_USER + 100; i++) {
+      await store.recordMessage(guildId, userId, {
+        id: `msg-${i}`,
+        channelId: 'chan',
+        content: `message ${i}`,
+        createdTimestamp: 1_000 + i,
+      });
+    }
+    const logs = store.getRecentMessages(guildId, userId, store.MAX_PER_USER);
+    assert.equal(logs.length, store.MAX_PER_USER);
+    assert.equal(logs[0].id, `msg-100`);
+    assert.equal(logs.at(-1).id, `msg-${store.MAX_PER_USER + 99}`);
+
+    const file = path.join(process.env.DUSSCORD_DATA_DIR, 'user_messages.json');
+    assert.ok(fs.existsSync(file));
+  });
+});
+
+test('sanitises mentions and records attachments when content empty', async () => {
+  await withTempStore(async store => {
+    const guildId = 'guild';
+    const userId = 'user';
+    await store.recordMessage(guildId, userId, {
+      id: 'msg-1',
+      channelId: 'chan',
+      content: 'Hello <@123> and <#456>',
+      createdTimestamp: 500,
+    });
+    await store.recordMessage(guildId, userId, {
+      id: 'msg-2',
+      channelId: 'chan',
+      content: '',
+      createdTimestamp: 600,
+      attachments: new Map([
+        ['a', { name: 'file.png' }],
+      ]),
+    });
+
+    const logs = store.getRecentMessages(guildId, userId, 10);
+    assert.equal(logs.length, 2);
+    assert.match(logs[0].content, /Hello \[@123\] and \[#channel:456\]/);
+    assert.match(logs[1].content, /Attachments: file\.png/);
+  });
+});


### PR DESCRIPTION
## Summary
- add a Judgement currency with storage, message logging, and inventory visibility
- add the /analysis command that spends a Judgement to analyse the last 1,000 messages via the configured persona
- add an owner-only /givejudgement command plus tests covering the new stores and inventory output

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d780bb0d588331b433e3373fe4f99f