### PR TITLE
Attach confession button to confession posts

### DIFF
--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -1,4 +1,4 @@
-const { Events, PermissionsBitField, EmbedBuilder, ModalBuilder, ActionRowBuilder, TextInputBuilder, TextInputStyle } = require('discord.js');
+const { Events, PermissionsBitField, EmbedBuilder, ModalBuilder, ActionRowBuilder, TextInputBuilder, TextInputStyle, ButtonBuilder, ButtonStyle } = require('discord.js');
 const verifyStore = require('../utils/verificationStore');
 const securityLogger = require('../utils/securityLogger');
 const verifySession = require('../utils/verificationSession');
@@ -284,8 +284,14 @@ module.exports = {
                     applyDefaultColour(embed, interaction.guildId);
                 } catch (_) {}
 
+                const button = new ButtonBuilder()
+                    .setCustomId(`confess:open:${channel.id}`)
+                    .setLabel('Confess Anonymously')
+                    .setStyle(ButtonStyle.Success);
+                const buttonRow = new ActionRowBuilder().addComponents(button);
+
                 try {
-                    await channel.send({ embeds: [embed] });
+                    await channel.send({ embeds: [embed], components: [buttonRow] });
                 } catch (_) {
                     try { await interaction.reply({ content: 'Failed to send your confession. Please try again later.', ephemeral: true }); } catch (_) {}
                     return;


### PR DESCRIPTION
## Summary
- ensure each anonymous confession message includes a fresh confess button
- keep the confession button wired to the same channel for continued submissions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d7836a15188331816a47e7b0752e72