### PR TITLE
Handle dynamic data directory overrides

### DIFF
--- a/src/utils/antiNukeStore.js
+++ b/src/utils/antiNukeStore.js
@@ -2,7 +2,10 @@ const fs = require('fs').promises;
 const { ensureFile, resolveDataPath, writeJson } = require('./dataDir');
 
 const STORE_FILE = 'antinuke.json';
-const dataFile = resolveDataPath(STORE_FILE);
+
+function getDataFile() {
+  return resolveDataPath(STORE_FILE);
+}
 
 let cache = null;
 
@@ -63,7 +66,7 @@ async function ensureLoaded() {
   if (cache) return;
   try {
     await ensureFile(STORE_FILE, '{}');
-    const raw = await fs.readFile(dataFile, 'utf8').catch(err => {
+    const raw = await fs.readFile(getDataFile(), 'utf8').catch(err => {
       if (err?.code === 'ENOENT') return '{}';
       throw err;
     });

--- a/src/utils/autoPostStore.js
+++ b/src/utils/autoPostStore.js
@@ -2,7 +2,10 @@ const fs = require('fs/promises');
 const { ensureFile, resolveDataPath, writeJson } = require('./dataDir');
 
 const STORE_FILE = 'autopost.json';
-const dataFile = resolveDataPath(STORE_FILE);
+
+function getDataFile() {
+  return resolveDataPath(STORE_FILE);
+}
 
 let cache = null;
 let loadPromise = null;
@@ -14,7 +17,7 @@ async function ensureLoaded() {
   loadPromise = (async () => {
     try {
       await ensureFile(STORE_FILE, '{}');
-      const raw = await fs.readFile(dataFile, 'utf8').catch(err => {
+      const raw = await fs.readFile(getDataFile(), 'utf8').catch(err => {
         if (err.code === 'ENOENT') return '{}';
         throw err;
       });

--- a/src/utils/autoRespondStore.js
+++ b/src/utils/autoRespondStore.js
@@ -2,7 +2,10 @@ const fs = require('fs');
 const { ensureFileSync, resolveDataPath, writeJsonSync } = require('./dataDir');
 
 const STORE_FILE = 'autorespond.json';
-const dataFile = resolveDataPath(STORE_FILE);
+
+function getDataFile() {
+  return resolveDataPath(STORE_FILE);
+}
 
 let cache = null;
 
@@ -10,7 +13,7 @@ function ensureLoaded() {
   if (cache) return;
   try {
     ensureFileSync(STORE_FILE, '{}');
-    const raw = fs.readFileSync(dataFile, 'utf8');
+    const raw = fs.readFileSync(getDataFile(), 'utf8');
     cache = raw ? JSON.parse(raw) : {};
     if (!cache || typeof cache !== 'object') cache = {};
   } catch (err) {

--- a/src/utils/autorolesStore.js
+++ b/src/utils/autorolesStore.js
@@ -2,7 +2,10 @@ const fs = require('fs');
 const { ensureFileSync, resolveDataPath, writeJsonSync } = require('./dataDir');
 
 const STORE_FILE = 'autoroles.json';
-const dataFile = resolveDataPath(STORE_FILE);
+
+function getDataFile() {
+    return resolveDataPath(STORE_FILE);
+}
 
 let cache = null;
 
@@ -10,7 +13,7 @@ function ensureLoaded() {
     if (!cache) {
         try {
             ensureFileSync(STORE_FILE, '{}');
-            const raw = fs.readFileSync(dataFile, 'utf8');
+            const raw = fs.readFileSync(getDataFile(), 'utf8');
             cache = raw ? JSON.parse(raw) : {};
             if (!cache || typeof cache !== 'object') cache = {};
         } catch (e) {

--- a/src/utils/blacklistStore.js
+++ b/src/utils/blacklistStore.js
@@ -2,7 +2,10 @@ const fs = require('fs/promises');
 const { ensureFile, resolveDataPath, writeJson } = require('./dataDir');
 
 const STORE_FILE = 'blacklist.json';
-const FILE = resolveDataPath(STORE_FILE);
+
+function getFilePath() {
+  return resolveDataPath(STORE_FILE);
+}
 
 let cache = null;
 let saveTimeout = null;
@@ -19,7 +22,7 @@ async function load() {
   if (cache) return cache;
   await ensureStoreFile();
   try {
-    const raw = await fs.readFile(FILE, 'utf8');
+    const raw = await fs.readFile(getFilePath(), 'utf8');
     const parsed = JSON.parse(raw || '{}');
     if (!parsed.guilds || typeof parsed.guilds !== 'object') parsed.guilds = {};
     cache = parsed;

--- a/src/utils/guildColourStore.js
+++ b/src/utils/guildColourStore.js
@@ -5,7 +5,10 @@ const { ensureFileSync, resolveDataPath, writeJson } = require('./dataDir');
 const DEFAULT_EMBED_COLOUR = 0xf10909;
 
 const STORE_FILE_NAME = 'embed_colours.json';
-const STORE_FILE = resolveDataPath(STORE_FILE_NAME);
+
+function getStoreFilePath() {
+  return resolveDataPath(STORE_FILE_NAME);
+}
 
 function ensureStore() {
   try {
@@ -19,7 +22,7 @@ function ensureStore() {
 function readStore() {
   ensureStore();
   try {
-    const raw = fs.readFileSync(STORE_FILE, 'utf8');
+    const raw = fs.readFileSync(getStoreFilePath(), 'utf8');
     const json = JSON.parse(raw);
     return json && typeof json === 'object' && json.guilds ? json : { guilds: {} };
   } catch {

--- a/src/utils/horseRaceStore.js
+++ b/src/utils/horseRaceStore.js
@@ -3,7 +3,10 @@ const { ensureFileSync, resolveDataPath, writeJsonSync } = require('./dataDir');
 
 const STORE_FILE = 'horserace.json';
 const DEFAULT_STORE = { guilds: {} };
-const dataFile = resolveDataPath(STORE_FILE);
+
+function getDataFile() {
+  return resolveDataPath(STORE_FILE);
+}
 
 let cache = null;
 
@@ -11,7 +14,7 @@ function ensureLoaded() {
   if (cache) return;
   try {
     ensureFileSync(STORE_FILE, JSON.stringify(DEFAULT_STORE, null, 2));
-    const raw = fs.readFileSync(dataFile, 'utf8');
+    const raw = fs.readFileSync(getDataFile(), 'utf8');
     const parsed = raw ? JSON.parse(raw) : null;
     if (!parsed || typeof parsed !== 'object') {
       cache = { ...DEFAULT_STORE };

--- a/src/utils/jailStore.js
+++ b/src/utils/jailStore.js
@@ -2,7 +2,10 @@ const fs = require('fs/promises');
 const { ensureFile, resolveDataPath, writeJson } = require('./dataDir');
 
 const STORE_FILE = 'jail.json';
-const FILE = resolveDataPath(STORE_FILE);
+
+function getFilePath() {
+  return resolveDataPath(STORE_FILE);
+}
 
 let cache = null;
 let saveTimeout = null;
@@ -19,7 +22,7 @@ async function load() {
   if (cache) return cache;
   await ensureStoreFile();
   try {
-    const raw = await fs.readFile(FILE, 'utf8');
+    const raw = await fs.readFile(getFilePath(), 'utf8');
     const parsed = JSON.parse(raw || '{}');
     if (!parsed.guilds || typeof parsed.guilds !== 'object') parsed.guilds = {};
     cache = parsed;

--- a/src/utils/joinLeaveStore.js
+++ b/src/utils/joinLeaveStore.js
@@ -2,7 +2,10 @@ const fs = require('fs');
 const { ensureFileSync, resolveDataPath, writeJsonSync } = require('./dataDir');
 
 const STORE_FILE = 'joins_leaves.json';
-const dataFile = resolveDataPath(STORE_FILE);
+
+function getDataFile() {
+  return resolveDataPath(STORE_FILE);
+}
 
 let cache = null;
 
@@ -10,8 +13,9 @@ function load() {
   if (cache) return cache;
   try {
     ensureFileSync(STORE_FILE, { guilds: {} });
-    if (fs.existsSync(dataFile)) {
-      const raw = fs.readFileSync(dataFile, 'utf8');
+    const filePath = getDataFile();
+    if (fs.existsSync(filePath)) {
+      const raw = fs.readFileSync(filePath, 'utf8');
       cache = raw ? JSON.parse(raw) : { guilds: {} };
     } else {
       cache = { guilds: {} };

--- a/src/utils/joinLogConfigStore.js
+++ b/src/utils/joinLogConfigStore.js
@@ -2,7 +2,10 @@ const fs = require('fs');
 const { ensureFileSync, resolveDataPath, writeJsonSync } = require('./dataDir');
 
 const STORE_FILE = 'joinlog_config.json';
-const dataFile = resolveDataPath(STORE_FILE);
+
+function getDataFile() {
+  return resolveDataPath(STORE_FILE);
+}
 
 let cache = null;
 
@@ -10,7 +13,8 @@ function load() {
   if (cache) return cache;
   try {
     ensureFileSync(STORE_FILE, {});
-    cache = fs.existsSync(dataFile) ? JSON.parse(fs.readFileSync(dataFile, 'utf8') || '{}') : {};
+    const filePath = getDataFile();
+    cache = fs.existsSync(filePath) ? JSON.parse(fs.readFileSync(filePath, 'utf8') || '{}') : {};
   } catch (err) {
     console.error('Failed to load join log config store:', err);
     cache = {};

--- a/src/utils/judgementStore.js
+++ b/src/utils/judgementStore.js
@@ -1,14 +1,18 @@
 const fs = require('fs');
 const { ensureFileSync, resolveDataPath, writeJson } = require('./dataDir');
 
-const STORE_FILE = resolveDataPath('judgement_tokens.json');
+const STORE_FILE_NAME = 'judgement_tokens.json';
 const AWARD_THRESHOLD = 500;
 
 let cache = null;
 
+function getStoreFilePath() {
+  return resolveDataPath(STORE_FILE_NAME);
+}
+
 function ensureStoreFile() {
   try {
-    ensureFileSync('judgement_tokens.json', { guilds: {} });
+    ensureFileSync(STORE_FILE_NAME, { guilds: {} });
   } catch (err) {
     console.error('Failed to initialise judgement token store', err);
   }
@@ -18,7 +22,7 @@ function loadStore() {
   if (cache) return cache;
   ensureStoreFile();
   try {
-    const raw = fs.readFileSync(STORE_FILE, 'utf8');
+    const raw = fs.readFileSync(getStoreFilePath(), 'utf8');
     const parsed = JSON.parse(raw);
     if (!parsed || typeof parsed !== 'object') {
       cache = { guilds: {} };

--- a/src/utils/leaveStore.js
+++ b/src/utils/leaveStore.js
@@ -2,7 +2,10 @@ const fs = require('fs');
 const { ensureFileSync, resolveDataPath, writeJsonSync } = require('./dataDir');
 
 const STORE_FILE = 'leave.json';
-const file = resolveDataPath(STORE_FILE);
+
+function getFilePath() {
+  return resolveDataPath(STORE_FILE);
+}
 
 let cache = null;
 
@@ -16,7 +19,7 @@ function load() {
   if (cache) return cache;
   ensure();
   try {
-    cache = JSON.parse(fs.readFileSync(file, 'utf8')) || {};
+    cache = JSON.parse(fs.readFileSync(getFilePath(), 'utf8')) || {};
   } catch {
     cache = {};
   }

--- a/src/utils/logChannelsStore.js
+++ b/src/utils/logChannelsStore.js
@@ -2,7 +2,10 @@ const fs = require('fs').promises;
 const { ensureFile, resolveDataPath, writeJson } = require('./dataDir');
 
 const STORE_FILE = 'logchannels.json';
-const dataFile = resolveDataPath(STORE_FILE);
+
+function getDataFile() {
+  return resolveDataPath(STORE_FILE);
+}
 
 let cache = null;
 
@@ -10,7 +13,7 @@ async function ensureLoaded() {
   if (cache) return;
   try {
     await ensureFile(STORE_FILE, '{}');
-    const raw = await fs.readFile(dataFile, 'utf8').catch(err => {
+    const raw = await fs.readFile(getDataFile(), 'utf8').catch(err => {
       if (err?.code === 'ENOENT') return '{}';
       throw err;
     });

--- a/src/utils/messageTokenStore.js
+++ b/src/utils/messageTokenStore.js
@@ -1,14 +1,18 @@
 const fs = require('fs');
 const { ensureFileSync, resolveDataPath, writeJson } = require('./dataDir');
 
-const STORE_FILE = resolveDataPath('message_tokens.json');
+const STORE_FILE_NAME = 'message_tokens.json';
 const AWARD_THRESHOLD = 200;
 
 let cache = null;
 
+function getStoreFilePath() {
+  return resolveDataPath(STORE_FILE_NAME);
+}
+
 function ensureStoreFile() {
   try {
-    ensureFileSync('message_tokens.json', { guilds: {} });
+    ensureFileSync(STORE_FILE_NAME, { guilds: {} });
   } catch (err) {
     console.error('Failed to initialise message token store', err);
   }
@@ -18,7 +22,7 @@ function loadStore() {
   if (cache) return cache;
   ensureStoreFile();
   try {
-    const raw = fs.readFileSync(STORE_FILE, 'utf8');
+    const raw = fs.readFileSync(getStoreFilePath(), 'utf8');
     const parsed = JSON.parse(raw);
     if (!parsed || typeof parsed !== 'object') {
       cache = { guilds: {} };

--- a/src/utils/modLogStore.js
+++ b/src/utils/modLogStore.js
@@ -2,7 +2,10 @@ const fs = require('fs').promises;
 const { ensureFile, resolveDataPath, writeJson } = require('./dataDir');
 
 const STORE_FILE = 'modlog.json';
-const dataFile = resolveDataPath(STORE_FILE);
+
+function getDataFile() {
+  return resolveDataPath(STORE_FILE);
+}
 
 let cache = null;
 
@@ -10,7 +13,7 @@ async function ensureLoaded() {
   if (cache) return;
   try {
     await ensureFile(STORE_FILE, '{}');
-    const raw = await fs.readFile(dataFile, 'utf8').catch(err => {
+    const raw = await fs.readFile(getDataFile(), 'utf8').catch(err => {
       if (err?.code === 'ENOENT') return '{}';
       throw err;
     });

--- a/src/utils/securityEventsStore.js
+++ b/src/utils/securityEventsStore.js
@@ -2,7 +2,10 @@ const fs = require('fs').promises;
 const { ensureFile, resolveDataPath, writeJson } = require('./dataDir');
 
 const STORE_FILE = 'securityevents.json';
-const dataFile = resolveDataPath(STORE_FILE);
+
+function getDataFile() {
+  return resolveDataPath(STORE_FILE);
+}
 const DEFAULT_STORE = { events: [] };
 
 let cache = null;
@@ -11,7 +14,7 @@ async function load() {
   if (cache) return cache;
   try {
     await ensureFile(STORE_FILE, DEFAULT_STORE);
-    const raw = await fs.readFile(dataFile, 'utf8').catch(err => {
+    const raw = await fs.readFile(getDataFile(), 'utf8').catch(err => {
       if (err?.code === 'ENOENT') return '';
       throw err;
     });

--- a/src/utils/securityLogStore.js
+++ b/src/utils/securityLogStore.js
@@ -2,7 +2,10 @@ const fs = require('fs').promises;
 const { ensureFile, resolveDataPath, writeJson } = require('./dataDir');
 
 const STORE_FILE = 'securitylog.json';
-const dataFile = resolveDataPath(STORE_FILE);
+
+function getDataFile() {
+  return resolveDataPath(STORE_FILE);
+}
 
 let cache = null;
 
@@ -10,7 +13,7 @@ async function ensureLoaded() {
   if (cache) return;
   try {
     await ensureFile(STORE_FILE, '{}');
-    const raw = await fs.readFile(dataFile, 'utf8').catch(err => {
+    const raw = await fs.readFile(getDataFile(), 'utf8').catch(err => {
       if (err?.code === 'ENOENT') return '{}';
       throw err;
     });

--- a/src/utils/serverTagStore.js
+++ b/src/utils/serverTagStore.js
@@ -2,8 +2,11 @@ const fs = require('fs');
 const { ensureFileSync, resolveDataPath, writeJson } = require('./dataDir');
 
 const STORE_FILE_NAME = 'server_tags.json';
-const STORE_FILE = resolveDataPath(STORE_FILE_NAME);
 const MAX_TAG_LENGTH = 32;
+
+function getStoreFilePath() {
+  return resolveDataPath(STORE_FILE_NAME);
+}
 
 function ensureStore() {
   try {
@@ -16,7 +19,7 @@ function ensureStore() {
 function readStore() {
   ensureStore();
   try {
-    const raw = fs.readFileSync(STORE_FILE, 'utf8');
+    const raw = fs.readFileSync(getStoreFilePath(), 'utf8');
     const parsed = JSON.parse(raw);
     if (!parsed || typeof parsed !== 'object') return { guilds: {} };
     if (!parsed.guilds || typeof parsed.guilds !== 'object') parsed.guilds = {};

--- a/src/utils/streamLogStore.js
+++ b/src/utils/streamLogStore.js
@@ -2,7 +2,10 @@ const fs = require('fs').promises;
 const { ensureFile, resolveDataPath, writeJson } = require('./dataDir');
 
 const STORE_FILE = 'streamlogs.json';
-const dataFile = resolveDataPath(STORE_FILE);
+
+function getDataFile() {
+  return resolveDataPath(STORE_FILE);
+}
 
 let cache = null;
 
@@ -23,7 +26,7 @@ async function ensureLoaded() {
   if (cache) return;
   try {
     await ensureFile(STORE_FILE, '{}');
-    const raw = await fs.readFile(dataFile, 'utf8').catch(err => {
+    const raw = await fs.readFile(getDataFile(), 'utf8').catch(err => {
       if (err?.code === 'ENOENT') return '{}';
       throw err;
     });

--- a/src/utils/userMessageLogStore.js
+++ b/src/utils/userMessageLogStore.js
@@ -1,14 +1,18 @@
 const fs = require('fs');
 const { ensureFileSync, resolveDataPath, writeJson } = require('./dataDir');
 
-const STORE_FILE = resolveDataPath('user_messages.json');
+const STORE_FILE_NAME = 'user_messages.json';
 const MAX_PER_USER = 1000;
 
 let cache = null;
 
+function getStoreFilePath() {
+  return resolveDataPath(STORE_FILE_NAME);
+}
+
 function ensureStoreFile() {
   try {
-    ensureFileSync('user_messages.json', { guilds: {} });
+    ensureFileSync(STORE_FILE_NAME, { guilds: {} });
   } catch (err) {
     console.error('Failed to initialise user message log store', err);
   }
@@ -18,7 +22,7 @@ function loadStore() {
   if (cache) return cache;
   ensureStoreFile();
   try {
-    const raw = fs.readFileSync(STORE_FILE, 'utf8');
+    const raw = fs.readFileSync(getStoreFilePath(), 'utf8');
     const parsed = JSON.parse(raw);
     if (!parsed || typeof parsed !== 'object') {
       cache = { guilds: {} };
@@ -36,7 +40,7 @@ async function saveStore() {
   ensureStoreFile();
   const safe = cache && typeof cache === 'object' ? cache : { guilds: {} };
   if (!safe.guilds || typeof safe.guilds !== 'object') safe.guilds = {};
-  await writeJson('user_messages.json', safe);
+  await writeJson(STORE_FILE_NAME, safe);
 }
 
 function ensureGuildUser(guildId, userId) {

--- a/src/utils/verificationStore.js
+++ b/src/utils/verificationStore.js
@@ -2,7 +2,10 @@ const fs = require('fs');
 const { ensureFileSync, resolveDataPath, writeJsonSync } = require('./dataDir');
 
 const STORE_FILE = 'verification.json';
-const dataFile = resolveDataPath(STORE_FILE);
+
+function getDataFile() {
+  return resolveDataPath(STORE_FILE);
+}
 
 let cache = null;
 
@@ -10,8 +13,9 @@ function ensureLoaded() {
   if (cache) return;
   try {
     ensureFileSync(STORE_FILE, {});
-    if (fs.existsSync(dataFile)) {
-      const raw = fs.readFileSync(dataFile, 'utf8');
+    const filePath = getDataFile();
+    if (fs.existsSync(filePath)) {
+      const raw = fs.readFileSync(filePath, 'utf8');
       cache = raw ? JSON.parse(raw) : {};
     } else {
       cache = {};

--- a/src/utils/welcomeStore.js
+++ b/src/utils/welcomeStore.js
@@ -2,7 +2,10 @@ const fs = require('fs');
 const { ensureFileSync, resolveDataPath, writeJsonSync } = require('./dataDir');
 
 const STORE_FILE = 'welcome.json';
-const file = resolveDataPath(STORE_FILE);
+
+function getFilePath() {
+  return resolveDataPath(STORE_FILE);
+}
 
 let cache = null;
 
@@ -16,7 +19,7 @@ function load() {
   if (cache) return cache;
   ensure();
   try {
-    cache = JSON.parse(fs.readFileSync(file, 'utf8')) || {};
+    cache = JSON.parse(fs.readFileSync(getFilePath(), 'utf8')) || {};
   } catch {
     cache = {};
   }

--- a/tests/boosterRoleStore.test.js
+++ b/tests/boosterRoleStore.test.js
@@ -6,6 +6,8 @@ const assert = require('node:assert/strict');
 
 const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dusscord-booster-store-'));
 process.env.DUSSCORD_DATA_DIR = tempDir;
+const { resetDataDirCache } = require('../src/utils/dataDir');
+resetDataDirCache();
 const dataFile = path.join(tempDir, 'boosterRoles.json');
 
 const modulePath = require.resolve('../src/utils/boosterRoleStore');
@@ -19,6 +21,12 @@ function loadStore() {
   delete require.cache[modulePath];
   return require(modulePath);
 }
+
+test.after(() => {
+  resetDataDirCache();
+  delete process.env.DUSSCORD_DATA_DIR;
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
 
 test('getRoleId converts legacy string entries and preserves colour data', async () => {
   await resetStoreFile({

--- a/tests/guildColourStore.test.js
+++ b/tests/guildColourStore.test.js
@@ -6,6 +6,8 @@ const assert = require('node:assert/strict');
 
 const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dusscord-guild-colour-'));
 process.env.DUSSCORD_DATA_DIR = tempDir;
+const { resetDataDirCache } = require('../src/utils/dataDir');
+resetDataDirCache();
 
 const modulePath = require.resolve('../src/utils/guildColourStore');
 delete require.cache[modulePath];
@@ -14,6 +16,12 @@ const {
   getDefaultColour,
   parseColour,
 } = require(modulePath);
+
+test.after(() => {
+  resetDataDirCache();
+  delete process.env.DUSSCORD_DATA_DIR;
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
 
 test('setDefaultColour accepts hex string input', async () => {
   const saved = await setDefaultColour('guild-hex', '#1a2b3c');

--- a/tests/judgementStore.test.js
+++ b/tests/judgementStore.test.js
@@ -5,16 +5,19 @@ const path = require('path');
 const os = require('os');
 
 const modulePath = require.resolve('../src/utils/judgementStore');
+const { resetDataDirCache } = require('../src/utils/dataDir');
 
 async function withTempStore(fn) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'judgements-'));
   delete require.cache[modulePath];
   process.env.DUSSCORD_DATA_DIR = tmpDir;
+  resetDataDirCache();
   const store = require(modulePath);
   try {
     await fn(store, tmpDir);
   } finally {
     delete require.cache[modulePath];
+    resetDataDirCache();
     delete process.env.DUSSCORD_DATA_DIR;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }

--- a/tests/logconfig.test.js
+++ b/tests/logconfig.test.js
@@ -6,12 +6,20 @@ const assert = require('node:assert/strict');
 
 const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dusscord-logconfig-'));
 process.env.DUSSCORD_DATA_DIR = tempDir;
+const { resetDataDirCache } = require('../src/utils/dataDir');
+resetDataDirCache();
 
 const logconfig = require('../src/commands/logconfig');
 const securityLogStore = require('../src/utils/securityLogStore');
 const modLogStore = require('../src/utils/modLogStore');
 const logChannelsStore = require('../src/utils/logChannelsStore');
 const joinLogConfigStore = require('../src/utils/joinLogConfigStore');
+
+test.after(() => {
+  resetDataDirCache();
+  delete process.env.DUSSCORD_DATA_DIR;
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
 
 function createInteraction() {
   let reply;

--- a/tests/messageTokenStore.test.js
+++ b/tests/messageTokenStore.test.js
@@ -5,16 +5,19 @@ const path = require('path');
 const os = require('os');
 
 const modulePath = require.resolve('../src/utils/messageTokenStore');
+const { resetDataDirCache } = require('../src/utils/dataDir');
 
 async function withTempStore(fn) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bags-'));
   delete require.cache[modulePath];
   process.env.DUSSCORD_DATA_DIR = tmpDir;
+  resetDataDirCache();
   const store = require(modulePath);
   try {
     await fn(store, tmpDir);
   } finally {
     delete require.cache[modulePath];
+    resetDataDirCache();
     delete process.env.DUSSCORD_DATA_DIR;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }

--- a/tests/serverTagStore.test.js
+++ b/tests/serverTagStore.test.js
@@ -5,16 +5,19 @@ const path = require('path');
 const os = require('os');
 
 const modulePath = require.resolve('../src/utils/serverTagStore');
+const { resetDataDirCache } = require('../src/utils/dataDir');
 
 async function withTempStore(fn) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'servertag-'));
   delete require.cache[modulePath];
   process.env.DUSSCORD_DATA_DIR = tmpDir;
+  resetDataDirCache();
   const store = require(modulePath);
   try {
     await fn(store, tmpDir);
   } finally {
     delete require.cache[modulePath];
+    resetDataDirCache();
     delete process.env.DUSSCORD_DATA_DIR;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }

--- a/tests/smiteConfigStore.test.js
+++ b/tests/smiteConfigStore.test.js
@@ -5,21 +5,20 @@ const path = require('path');
 const os = require('os');
 
 const modulePath = require.resolve('../src/utils/smiteConfigStore');
-const dataDirPath = require.resolve('../src/utils/dataDir');
+const { resetDataDirCache } = require('../src/utils/dataDir');
 
 async function withTempStore(fn) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'smite-config-'));
   delete require.cache[modulePath];
-  delete require.cache[dataDirPath];
   process.env.DUSSCORD_DATA_DIR = tmpDir;
+  resetDataDirCache();
   const store = require(modulePath);
   try {
     await fn(store, tmpDir);
   } finally {
     delete require.cache[modulePath];
-    delete require.cache[dataDirPath];
     if (store?.clearCache) store.clearCache();
-    delete require.cache[modulePath];
+    resetDataDirCache();
     delete process.env.DUSSCORD_DATA_DIR;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }

--- a/tests/userMessageLogStore.test.js
+++ b/tests/userMessageLogStore.test.js
@@ -5,16 +5,19 @@ const path = require('path');
 const os = require('os');
 
 const modulePath = require.resolve('../src/utils/userMessageLogStore');
+const { resetDataDirCache } = require('../src/utils/dataDir');
 
 async function withTempStore(fn) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'user-messages-'));
   delete require.cache[modulePath];
   process.env.DUSSCORD_DATA_DIR = tmpDir;
+  resetDataDirCache();
   const store = require(modulePath);
   try {
     await fn(store, tmpDir);
   } finally {
     delete require.cache[modulePath];
+    resetDataDirCache();
     delete process.env.DUSSCORD_DATA_DIR;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- derive data storage paths from the current DUSSCORD_DATA_DIR and expose a cache reset helper
- update data stores to resolve their backing files on demand so environment overrides apply immediately
- reset the data directory cache in tests that swap DUSSCORD_DATA_DIR to ensure temporary folders are honoured

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d792c45e54833197e66b072756e9f7