### PR TITLE
Add trivia game commands and dataset

### DIFF
--- a/src/commands/triviacategories.js
+++ b/src/commands/triviacategories.js
@@ -1,0 +1,63 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const triviaData = require('../utils/triviaData');
+
+function formatCategoryLine(category) {
+  const description = category.description
+    ? category.description.slice(0, 180) + (category.description.length > 180 ? '…' : '')
+    : 'No description provided.';
+  const difficultyText = category.difficulties.length
+    ? category.difficulties
+      .map(entry => `${triviaData.formatDifficultyName(entry.key)} (${entry.questions})`)
+      .join(', ')
+    : 'No questions yet';
+
+  return `**${category.name}** (\`${category.id}\`)
+${description}
+Difficulties: ${difficultyText}`;
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('triviacategories')
+    .setDescription('Show the list of available trivia categories and difficulties')
+    .setDMPermission(false),
+
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ content: 'Use this command inside a server.', ephemeral: true });
+    }
+
+    const categories = triviaData.listCategories();
+    if (!categories.length) {
+      return interaction.reply({ content: 'No trivia categories are available yet.', ephemeral: true });
+    }
+
+    const lines = categories.map(formatCategoryLine);
+    const embeds = [];
+    let buffer = '';
+
+    for (const line of lines) {
+      const next = buffer ? `${buffer}\n\n${line}` : line;
+      if (next.length > 3800 && buffer) {
+        embeds.push(new EmbedBuilder()
+          .setColor(0x5865F2)
+          .setTitle('Trivia Categories')
+          .setDescription(buffer)
+          .setFooter({ text: 'Use /triviastart to begin a game in your favourite category.' }));
+        buffer = line;
+      } else {
+        buffer = next;
+      }
+    }
+
+    if (buffer) {
+      embeds.push(new EmbedBuilder()
+        .setColor(0x5865F2)
+        .setTitle('Trivia Categories')
+        .setDescription(buffer)
+        .setFooter({ text: 'Use /triviastart to begin a game in your favourite category.' }));
+    }
+
+    return interaction.reply({ embeds });
+  },
+};

--- a/src/commands/triviarankings.js
+++ b/src/commands/triviarankings.js
@@ -1,0 +1,76 @@
+const { SlashCommandBuilder, EmbedBuilder, escapeMarkdown } = require('discord.js');
+const triviaStatsStore = require('../utils/triviaStatsStore');
+
+async function resolveDisplayName(guild, userId) {
+  if (!guild) return `User ${userId}`;
+  try {
+    const member = await guild.members.fetch(userId);
+    const display = member.displayName || member.user.globalName || member.user.username;
+    return display ? escapeMarkdown(display) : `User ${userId}`;
+  } catch (err) {
+    try {
+      const user = await guild.client.users.fetch(userId);
+      const name = user.globalName || user.username;
+      return name ? escapeMarkdown(name) : `User ${userId}`;
+    } catch (_) {
+      return `User ${userId}`;
+    }
+  }
+}
+
+function formatLeaderboardLine(entry, index) {
+  const parts = [];
+  if (entry.firstPlace) parts.push(`${entry.firstPlace} win${entry.firstPlace === 1 ? '' : 's'}`);
+  if (entry.secondPlace) parts.push(`${entry.secondPlace} runner-up${entry.secondPlace === 1 ? '' : 's'}`);
+  if (entry.thirdPlace) parts.push(`${entry.thirdPlace} third-place`);
+  if (entry.correctAnswers) parts.push(`${entry.correctAnswers} correct`);
+  if (entry.gamesPlayed) parts.push(`${entry.gamesPlayed} game${entry.gamesPlayed === 1 ? '' : 's'}`);
+
+  const accuracy = entry.roundsParticipated > 0
+    ? Math.round((entry.correctAnswers / entry.roundsParticipated) * 100)
+    : null;
+  const accuracyText = accuracy !== null ? `${accuracy}% accuracy` : 'No rounds recorded';
+  const coinsText = entry.coinsEarned > 0 ? `${entry.coinsEarned} coins earned` : null;
+
+  const details = parts.length ? parts.join(', ') : 'No stats recorded yet';
+  const meta = coinsText ? `${accuracyText} • ${coinsText}` : accuracyText;
+
+  return `${index + 1}. **${entry.name}** — ${details} (${meta})`;
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('triviarankings')
+    .setDescription('View the historical trivia leaderboard for this server')
+    .setDMPermission(false),
+
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ content: 'Use this command in a server channel.', ephemeral: true });
+    }
+
+    await interaction.deferReply();
+
+    const leaderboard = triviaStatsStore.getLeaderboard(interaction.guildId);
+    if (!leaderboard.length) {
+      return interaction.editReply({ content: 'No trivia games have been recorded yet. Start one with /triviastart!' });
+    }
+
+    const topEntries = leaderboard.slice(0, 10);
+    const resolved = await Promise.all(topEntries.map(async (entry, index) => ({
+      ...entry,
+      name: await resolveDisplayName(interaction.guild, entry.userId),
+      index,
+    })));
+
+    const lines = resolved.map(entry => formatLeaderboardLine(entry, entry.index));
+
+    const embed = new EmbedBuilder()
+      .setColor(0x5865F2)
+      .setTitle('Trivia Leaderboard')
+      .setDescription(lines.join('\n'))
+      .setFooter({ text: 'Wins grant +20 coins and runners-up earn +10 coins.' });
+
+    return interaction.editReply({ embeds: [embed] });
+  },
+};

--- a/src/commands/triviastart.js
+++ b/src/commands/triviastart.js
@@ -1,0 +1,102 @@
+const { SlashCommandBuilder, PermissionsBitField } = require('discord.js');
+const triviaData = require('../utils/triviaData');
+const triviaGameManager = require('../utils/triviaGameManager');
+
+const categoriesForChoices = (() => {
+  const categories = triviaData.listCategories();
+  if (!categories.length || categories.length > 25) return [];
+  return categories.map(category => ({ name: category.name.slice(0, 100), value: category.id }));
+})();
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('triviastart')
+    .setDescription('Start a trivia game in the current channel')
+    .setDMPermission(false)
+    .addStringOption(option => {
+      option
+        .setName('category')
+        .setDescription('Category of questions to use')
+        .setRequired(true);
+      if (categoriesForChoices.length) {
+        option.addChoices(...categoriesForChoices);
+      }
+      return option;
+    })
+    .addStringOption(option =>
+      option
+        .setName('difficulty')
+        .setDescription('Question difficulty')
+        .setRequired(true)
+        .addChoices(
+          { name: 'Easy', value: 'easy' },
+          { name: 'Medium', value: 'medium' },
+          { name: 'Hard', value: 'hard' },
+        ),
+    )
+    .addIntegerOption(option =>
+      option
+        .setName('questions')
+        .setDescription('How many questions to ask (default 10)')
+        .setMinValue(1)
+        .setMaxValue(25),
+    ),
+
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ content: 'Use this command in a server channel.', ephemeral: true });
+    }
+
+    const channel = interaction.channel;
+    if (!channel || typeof channel.isTextBased !== 'function' || !channel.isTextBased()) {
+      return interaction.reply({ content: 'Trivia can only run in text-based channels.', ephemeral: true });
+    }
+
+    const mePermissions = channel.permissionsFor(interaction.client.user);
+    if (!mePermissions?.has(PermissionsBitField.Flags.SendMessages)) {
+      return interaction.reply({ content: 'I need permission to send messages in this channel to start trivia.', ephemeral: true });
+    }
+    if (!mePermissions?.has(PermissionsBitField.Flags.EmbedLinks)) {
+      return interaction.reply({ content: 'I need the Embed Links permission in this channel to host trivia.', ephemeral: true });
+    }
+
+    const rawCategoryId = interaction.options.getString('category', true);
+    const difficultyInput = interaction.options.getString('difficulty', true);
+    const requestedQuestions = interaction.options.getInteger('questions');
+
+    const normalisedDifficulty = triviaData.normaliseDifficultyKey(difficultyInput);
+    if (!normalisedDifficulty) {
+      return interaction.reply({ content: 'Please choose a valid difficulty (easy, medium, or hard).', ephemeral: true });
+    }
+
+    let category = triviaData.getCategory(rawCategoryId);
+    if (!category) {
+      const match = triviaData.listCategories().find(cat => cat.id.toLowerCase() === rawCategoryId.toLowerCase());
+      if (match) category = triviaData.getCategory(match.id);
+    }
+    if (!category) {
+      return interaction.reply({ content: 'That category could not be found. Use /triviacategories for a list.', ephemeral: true });
+    }
+
+    const pool = category.difficulties[normalisedDifficulty];
+    if (!pool || !pool.length) {
+      return interaction.reply({ content: 'There are no questions uploaded for that difficulty yet.', ephemeral: true });
+    }
+
+    const desiredCount = requestedQuestions ?? undefined;
+
+    const result = await triviaGameManager.startTriviaGame(interaction, {
+      categoryId: category.id,
+      difficulty: normalisedDifficulty,
+      questionCount: desiredCount,
+    });
+
+    if (!result.ok) {
+      return interaction.reply({ content: result.error || 'Unable to start trivia right now.', ephemeral: true });
+    }
+
+    const acknowledgement = `Starting **${category.name}** trivia (${triviaData.formatDifficultyName(normalisedDifficulty)}) with ${result.questionCount} question${result.questionCount === 1 ? '' : 's'} in ${channel}. Good luck!`;
+
+    return interaction.reply({ content: acknowledgement, ephemeral: true });
+  },
+};

--- a/src/commands/triviastop.js
+++ b/src/commands/triviastop.js
@@ -1,0 +1,36 @@
+const { SlashCommandBuilder, PermissionsBitField } = require('discord.js');
+const triviaGameManager = require('../utils/triviaGameManager');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('triviastop')
+    .setDescription('Stop the active trivia game in this channel')
+    .setDMPermission(false),
+
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ content: 'Use this command in a server channel.', ephemeral: true });
+    }
+
+    const game = triviaGameManager.getActiveGame(interaction.guildId, interaction.channelId);
+    if (!game) {
+      return interaction.reply({ content: 'There is no active trivia game in this channel.', ephemeral: true });
+    }
+
+    const canStop = interaction.user.id === game.hostId
+      || interaction.memberPermissions?.has(PermissionsBitField.Flags.ManageGuild)
+      || interaction.memberPermissions?.has(PermissionsBitField.Flags.ManageChannels)
+      || interaction.memberPermissions?.has(PermissionsBitField.Flags.ModerateMembers);
+
+    if (!canStop) {
+      return interaction.reply({ content: 'Only the host or a server moderator can stop this trivia game.', ephemeral: true });
+    }
+
+    const stopped = triviaGameManager.stopTriviaGame(interaction.guildId, interaction.channelId, 'cancelled-by-user');
+    if (!stopped) {
+      return interaction.reply({ content: 'The trivia game could not be stopped.', ephemeral: true });
+    }
+
+    return interaction.reply({ content: 'The trivia game will wrap up after the current question.', ephemeral: true });
+  },
+};

--- a/src/data/trivia/drugs_narcotics.json
+++ b/src/data/trivia/drugs_narcotics.json
@@ -1,0 +1,613 @@
+{
+  "id": "drugs_narcotics",
+  "name": "Drugs and Narcotics",
+  "description": "Trivia focused on recreational drugs, their history, and policy milestones.",
+  "difficulties": {
+    "easy": [
+      {
+        "prompt": "Which plant is the source of cocaine?",
+        "choices": {
+          "A": "Tobacco",
+          "B": "Coffee",
+          "C": "Coca",
+          "D": "Opium"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "Marijuana is most commonly consumed by:",
+        "choices": {
+          "A": "Injection",
+          "B": "Smoking",
+          "C": "Snorting",
+          "D": "IV drip"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "Which drug is often referred to as 'weed'?",
+        "choices": {
+          "A": "LSD",
+          "B": "Heroin",
+          "C": "Cannabis",
+          "D": "Cocaine"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "What year did Canada legalize recreational cannabis?",
+        "choices": {
+          "A": "2015",
+          "B": "2016",
+          "C": "2018",
+          "D": "2019"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "Which ancient civilization first recorded opium use?",
+        "choices": {
+          "A": "Romans",
+          "B": "Greeks",
+          "C": "Sumerians",
+          "D": "Egyptians"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "Which stimulant is most commonly found in coffee and tea?",
+        "choices": {
+          "A": "Nicotine",
+          "B": "Caffeine",
+          "C": "Cocaine",
+          "D": "Morphine"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "Which drug is commonly known as 'acid'?",
+        "choices": {
+          "A": "Heroin",
+          "B": "LSD",
+          "C": "PCP",
+          "D": "Meth"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "Which U.S. president declared the 'War on Drugs'?",
+        "choices": {
+          "A": "Kennedy",
+          "B": "Johnson",
+          "C": "Nixon",
+          "D": "Reagan"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "What does 'THC' stand for?",
+        "choices": {
+          "A": "Tetrahydrocannabinol",
+          "B": "Tetrahydrocannabinol",
+          "C": "Trihydrocarbon",
+          "D": "Trichloride"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "Which drug is often prescribed as a painkiller?",
+        "choices": {
+          "A": "Cocaine",
+          "B": "LSD",
+          "C": "Morphine",
+          "D": "Caffeine"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "What color pill is commonly associated with ecstasy in pop culture?",
+        "choices": {
+          "A": "Green",
+          "B": "Blue",
+          "C": "Yellow",
+          "D": "Purple"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "Which illegal drug is often injected using a syringe?",
+        "choices": {
+          "A": "Cocaine",
+          "B": "Heroin",
+          "C": "LSD",
+          "D": "Cannabis"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "What is the slang term 'meth' short for?",
+        "choices": {
+          "A": "Methadone",
+          "B": "Methamphetamine",
+          "C": "Methyl alcohol",
+          "D": "Metrazine"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "Which drug is made from the poppy plant?",
+        "choices": {
+          "A": "Cocaine",
+          "B": "Opium",
+          "C": "LSD",
+          "D": "Caffeine"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "What country is famous for its coca leaf tea?",
+        "choices": {
+          "A": "Mexico",
+          "B": "Jamaica",
+          "C": "Peru",
+          "D": "China"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "Which drug is known as 'angel dust'?",
+        "choices": {
+          "A": "LSD",
+          "B": "Ecstasy",
+          "C": "PCP",
+          "D": "Ketamine"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "Which system of the body does alcohol primarily depress?",
+        "choices": {
+          "A": "Digestive",
+          "B": "Respiratory",
+          "C": "Central Nervous System",
+          "D": "Circulatory"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "Which drug is commonly smoked in a glass pipe?",
+        "choices": {
+          "A": "Heroin",
+          "B": "Crack Cocaine",
+          "C": "LSD",
+          "D": "Morphine"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "What does the slang term 'shrooms' refer to?",
+        "choices": {
+          "A": "Poppies",
+          "B": "LSD",
+          "C": "Psilocybin mushrooms",
+          "D": "Ecstasy"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "Which famous soda originally contained coca leaf extract?",
+        "choices": {
+          "A": "Pepsi",
+          "B": "Coca-Cola",
+          "C": "Dr. Pepper",
+          "D": "7-Up"
+        },
+        "answer": "B"
+      }
+    ],
+    "medium": [
+      {
+        "prompt": "LSD was discovered in 1938 by which Swiss chemist?",
+        "choices": {
+          "A": "Sigmund Freud",
+          "B": "Carl Jung",
+          "C": "Albert Hofmann",
+          "D": "Richard Evans"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "Which U.S. act in 1970 classified drugs into 'schedules'?",
+        "choices": {
+          "A": "Prohibition Act",
+          "B": "Controlled Substances Act",
+          "C": "Drug Enforcement Act",
+          "D": "Narcotics Control Act"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "What is the active compound in 'magic mushrooms'?",
+        "choices": {
+          "A": "DMT",
+          "B": "Psilocybin",
+          "C": "LSD",
+          "D": "THC"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "Methamphetamine was originally derived from which plant alkaloid?",
+        "choices": {
+          "A": "Nicotine",
+          "B": "Ephedrine",
+          "C": "Quinine",
+          "D": "Atropine"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "What does MDMA stand for?",
+        "choices": {
+          "A": "Methyldioxymethamphetamine",
+          "B": "3,4-Methylenedioxymethamphetamine",
+          "C": "Methyldioxyamphetamine",
+          "D": "Metadioxyamine"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "Which U.S. agency was created in 1973 to combat drugs?",
+        "choices": {
+          "A": "FDA",
+          "B": "CDC",
+          "C": "DEA",
+          "D": "NIH"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "In the 1800s, morphine was commonly marketed as a treatment for:",
+        "choices": {
+          "A": "Asthma",
+          "B": "Pain relief",
+          "C": "Tuberculosis",
+          "D": "Depression"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "Which indigenous people used peyote in religious ceremonies?",
+        "choices": {
+          "A": "Inuit",
+          "B": "Aztec",
+          "C": "Native American tribes",
+          "D": "Mayan"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "The 'Golden Triangle' is a major opium-producing region located in:",
+        "choices": {
+          "A": "South America",
+          "B": "Central Asia",
+          "C": "Southeast Asia",
+          "D": "Africa"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "Which neurotransmitter is boosted by ecstasy (MDMA)?",
+        "choices": {
+          "A": "GABA",
+          "B": "Norepinephrine",
+          "C": "Serotonin",
+          "D": "Glutamate"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "What does Narcan (naloxone) do?",
+        "choices": {
+          "A": "Enhances a high",
+          "B": "Causes hallucinations",
+          "C": "Reverses opioid overdoses",
+          "D": "Acts as a stimulant"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "Crack cocaine differs from powder cocaine because it is:",
+        "choices": {
+          "A": "Weaker",
+          "B": "Smoked in crystal form",
+          "C": "Less addictive",
+          "D": "Dissolved in liquid"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "The Harrison Narcotics Tax Act (1914) was the first U.S. law to regulate:",
+        "choices": {
+          "A": "Cannabis",
+          "B": "Opiates & Cocaine",
+          "C": "LSD",
+          "D": "Alcohol"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "What is methadone primarily used for?",
+        "choices": {
+          "A": "Hallucinations",
+          "B": "Treating opioid addiction",
+          "C": "Boosting energy",
+          "D": "Pain management only"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "The drug PCP was originally developed as a:",
+        "choices": {
+          "A": "Cough medicine",
+          "B": "Antibiotic",
+          "C": "Anesthetic",
+          "D": "Fertilizer"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "Which synthetic opioid is 50-100 times stronger than morphine?",
+        "choices": {
+          "A": "Methadone",
+          "B": "Oxycodone",
+          "C": "Fentanyl",
+          "D": "Codeine"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "Cocaine primarily affects which brain chemical?",
+        "choices": {
+          "A": "Acetylcholine",
+          "B": "Dopamine",
+          "C": "Histamine",
+          "D": "Melatonin"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "Which psychedelic was used in CIA experiments under 'MKUltra'?",
+        "choices": {
+          "A": "MDMA",
+          "B": "Mescaline",
+          "C": "LSD",
+          "D": "Psilocybin"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "In the 19th century, what narcotic was widely sold in patent medicines?",
+        "choices": {
+          "A": "LSD",
+          "B": "Cannabis",
+          "C": "Opium",
+          "D": "MDMA"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "Which South American drug cartel was led by Pablo Escobar?",
+        "choices": {
+          "A": "Cali Cartel",
+          "B": "Medellín Cartel",
+          "C": "Sinaloa Cartel",
+          "D": "Juárez Cartel"
+        },
+        "answer": "B"
+      }
+    ],
+    "hard": [
+      {
+        "prompt": "Which 19th-century war was fought largely over the opium trade?",
+        "choices": {
+          "A": "Spanish-American War",
+          "B": "Russo-Japanese War",
+          "C": "Opium Wars",
+          "D": "Boer War"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "'Speedball' is a dangerous mix of:",
+        "choices": {
+          "A": "Cocaine + LSD",
+          "B": "Cocaine + Heroin",
+          "C": "Ecstasy + Alcohol",
+          "D": "Meth + Nicotine"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "What chemical process turns morphine into heroin?",
+        "choices": {
+          "A": "Fermentation",
+          "B": "Acetylation",
+          "C": "Oxidation",
+          "D": "Hydrogenation"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "In what year did the U.S. pass the Marijuana Tax Act, effectively banning cannabis?",
+        "choices": {
+          "A": "1914",
+          "B": "1920",
+          "C": "1937",
+          "D": "1945"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "Which psychoactive compound is found in the Amazonian brew Ayahuasca?",
+        "choices": {
+          "A": "Mescaline",
+          "B": "LSD",
+          "C": "DMT",
+          "D": "Psilocin"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "What’s the main risk of combining benzodiazepines with opioids?",
+        "choices": {
+          "A": "High blood pressure",
+          "B": "Respiratory depression",
+          "C": "Seizures",
+          "D": "Liver failure"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "What is the half-life of methadone in the body?",
+        "choices": {
+          "A": "4–6 hours",
+          "B": "24–36 hours",
+          "C": "48–72 hours",
+          "D": "12–15 hours"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "Which UN convention in 1988 strengthened international drug enforcement?",
+        "choices": {
+          "A": "Geneva Protocol",
+          "B": "Single Convention",
+          "C": "UN Convention Against Illicit Traffic in Narcotic Drugs",
+          "D": "Vienna Pact"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "What receptor does THC primarily bind to in the brain?",
+        "choices": {
+          "A": "Dopamine",
+          "B": "CB1 (Cannabinoid receptor)",
+          "C": "GABA",
+          "D": "NMDA"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "'China White' is a street name for:",
+        "choices": {
+          "A": "Cocaine",
+          "B": "Meth",
+          "C": "Fentanyl",
+          "D": "Heroin"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "Which stimulant was widely used by soldiers in WWII to stay awake?",
+        "choices": {
+          "A": "Caffeine",
+          "B": "Amphetamines",
+          "C": "Cocaine",
+          "D": "Nicotine"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "What is the primary difference between Schedule I and Schedule II drugs (U.S.)?",
+        "choices": {
+          "A": "Both are illegal",
+          "B": "Schedule I has no accepted medical use, Schedule II does",
+          "C": "Schedule II is less addictive",
+          "D": "Schedule I includes alcohol"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "In which year did Portugal decriminalize all drugs for personal use?",
+        "choices": {
+          "A": "1995",
+          "B": "1999",
+          "C": "2001",
+          "D": "2005"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "What is the typical lethal dose of fentanyl in milligrams?",
+        "choices": {
+          "A": "10 mg",
+          "B": "2 mg",
+          "C": "50 mg",
+          "D": "0.5 mg"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "Which U.S. city is known for the 'Crack Epidemic' of the 1980s?",
+        "choices": {
+          "A": "Chicago",
+          "B": "Miami",
+          "C": "Los Angeles",
+          "D": "Detroit"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "What synthetic hallucinogen is nicknamed 'Special K'?",
+        "choices": {
+          "A": "PCP",
+          "B": "Ketamine",
+          "C": "MDMA",
+          "D": "Mescaline"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "Which precursor chemical is essential in making methamphetamine?",
+        "choices": {
+          "A": "Quinine",
+          "B": "Pseudoephedrine",
+          "C": "Benzene",
+          "D": "Lidocaine"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "The coca leaf has been traditionally chewed for centuries in:",
+        "choices": {
+          "A": "India",
+          "B": "Mexico",
+          "C": "Andes region",
+          "D": "Africa"
+        },
+        "answer": "C"
+      },
+      {
+        "prompt": "Which drug is considered the most addictive by rapid onset and short half-life?",
+        "choices": {
+          "A": "Alcohol",
+          "B": "Crack Cocaine",
+          "C": "LSD",
+          "D": "Cannabis"
+        },
+        "answer": "B"
+      },
+      {
+        "prompt": "What year did the UN adopt the Single Convention on Narcotic Drugs?",
+        "choices": {
+          "A": "1945",
+          "B": "1950",
+          "C": "1961",
+          "D": "1972"
+        },
+        "answer": "C"
+      }
+    ]
+  }
+}

--- a/src/utils/triviaData.js
+++ b/src/utils/triviaData.js
@@ -1,0 +1,249 @@
+const fs = require('fs');
+const path = require('path');
+const { resolveDataPath } = require('./dataDir');
+
+const TRIVIA_DIR = 'trivia';
+const DIFFICULTY_ORDER = ['easy', 'medium', 'hard'];
+
+let cachedCategories = null;
+
+function getCandidateDirectories() {
+  const dirs = [];
+  const fallback = path.join(__dirname, '..', 'data', TRIVIA_DIR);
+  const primary = resolveDataPath(TRIVIA_DIR);
+  if (fallback && !dirs.includes(fallback)) dirs.push(fallback);
+  if (primary && !dirs.includes(primary)) dirs.push(primary);
+  return dirs;
+}
+
+function normaliseDifficultyKey(value) {
+  const key = String(value || '').trim().toLowerCase();
+  if (!key) return null;
+  if (key.startsWith('easy')) return 'easy';
+  if (key.startsWith('med')) return 'medium';
+  if (key.startsWith('hard')) return 'hard';
+  return key;
+}
+
+function normaliseChoiceKey(key) {
+  if (!key && key !== 0) return null;
+  const letter = String(key).trim().charAt(0).toUpperCase();
+  return ['A', 'B', 'C', 'D'].includes(letter) ? letter : null;
+}
+
+function normaliseQuestion(rawQuestion, difficulty, index) {
+  if (!rawQuestion || typeof rawQuestion !== 'object') return null;
+
+  const prompt = String(rawQuestion.prompt || rawQuestion.question || '').trim();
+  if (!prompt) return null;
+
+  const choices = {};
+  if (rawQuestion.choices && typeof rawQuestion.choices === 'object') {
+    for (const [key, value] of Object.entries(rawQuestion.choices)) {
+      const letter = normaliseChoiceKey(key);
+      if (!letter) continue;
+      const text = value == null ? '' : String(value).trim();
+      if (!text) continue;
+      choices[letter] = text;
+    }
+  } else if (Array.isArray(rawQuestion.options)) {
+    rawQuestion.options.forEach((option, optIndex) => {
+      const letter = ['A', 'B', 'C', 'D'][optIndex];
+      if (!letter) return;
+      const text = option == null ? '' : String(option).trim();
+      if (!text) return;
+      choices[letter] = text;
+    });
+  }
+
+  const orderedChoices = {};
+  for (const letter of ['A', 'B', 'C', 'D']) {
+    if (choices[letter]) {
+      orderedChoices[letter] = choices[letter];
+    }
+  }
+
+  if (Object.keys(orderedChoices).length < 2) return null;
+
+  const answerKey = normaliseChoiceKey(rawQuestion.answer ?? rawQuestion.correct);
+  if (!answerKey || !orderedChoices[answerKey]) return null;
+
+  const explanation = typeof rawQuestion.explanation === 'string'
+    ? rawQuestion.explanation.trim()
+    : null;
+
+  return {
+    id: rawQuestion.id ? String(rawQuestion.id).trim() : `${difficulty}-${index + 1}`,
+    prompt,
+    choices: orderedChoices,
+    answer: answerKey,
+    explanation: explanation || null,
+  };
+}
+
+function normaliseCategory(rawCategory, fileName) {
+  if (!rawCategory || typeof rawCategory !== 'object') return null;
+
+  const id = String(rawCategory.id || path.basename(fileName, path.extname(fileName)) || '').trim();
+  if (!id) return null;
+
+  const name = String(rawCategory.name || id).trim();
+  const description = typeof rawCategory.description === 'string'
+    ? rawCategory.description.trim()
+    : '';
+
+  const difficultiesRaw = rawCategory.difficulties && typeof rawCategory.difficulties === 'object'
+    ? rawCategory.difficulties
+    : {};
+
+  const difficulties = {};
+  for (const [key, value] of Object.entries(difficultiesRaw)) {
+    const diffKey = normaliseDifficultyKey(key);
+    if (!diffKey) continue;
+    const list = Array.isArray(value) ? value : [];
+    const normalised = list
+      .map((question, index) => normaliseQuestion(question, diffKey, index))
+      .filter(Boolean);
+    if (normalised.length) {
+      difficulties[diffKey] = normalised;
+    }
+  }
+
+  const totalQuestions = Object.values(difficulties).reduce((sum, arr) => sum + arr.length, 0);
+  if (totalQuestions <= 0) return null;
+
+  return {
+    id,
+    name,
+    description,
+    difficulties,
+    totalQuestions,
+  };
+}
+
+function loadCategories() {
+  if (cachedCategories) return cachedCategories;
+
+  const categories = new Map();
+  const dirs = getCandidateDirectories();
+
+  for (const dir of dirs) {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch (err) {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+      const filePath = path.join(dir, entry.name);
+      try {
+        const raw = fs.readFileSync(filePath, 'utf8');
+        if (!raw) continue;
+        const parsed = JSON.parse(raw);
+        const category = normaliseCategory(parsed, entry.name);
+        if (!category) continue;
+        categories.set(category.id, category);
+      } catch (err) {
+        console.error(`Failed to load trivia category from ${filePath}:`, err);
+      }
+    }
+  }
+
+  cachedCategories = categories;
+  return categories;
+}
+
+function resetTriviaCache() {
+  cachedCategories = null;
+}
+
+function listCategories() {
+  const categories = loadCategories();
+  return Array.from(categories.values())
+    .map(category => ({
+      id: category.id,
+      name: category.name,
+      description: category.description,
+      totalQuestions: category.totalQuestions,
+      difficulties: DIFFICULTY_ORDER
+        .map(key => ({ key, questions: category.difficulties[key] ? category.difficulties[key].length : 0 }))
+        .filter(entry => entry.questions > 0),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function cloneQuestion(question) {
+  return {
+    id: question.id,
+    prompt: question.prompt,
+    choices: { ...question.choices },
+    answer: question.answer,
+    explanation: question.explanation,
+  };
+}
+
+function cloneCategory(category) {
+  const cloned = {
+    id: category.id,
+    name: category.name,
+    description: category.description,
+    totalQuestions: category.totalQuestions,
+    difficulties: {},
+  };
+  for (const [key, questions] of Object.entries(category.difficulties)) {
+    cloned.difficulties[key] = questions.map(cloneQuestion);
+  }
+  return cloned;
+}
+
+function getCategory(categoryId) {
+  if (!categoryId) return null;
+  const categories = loadCategories();
+  const category = categories.get(String(categoryId));
+  if (!category) return null;
+  return cloneCategory(category);
+}
+
+function getQuestionPool(categoryId, difficulty) {
+  const diffKey = normaliseDifficultyKey(difficulty);
+  if (!diffKey) return [];
+  const category = getCategory(categoryId);
+  if (!category) return [];
+  const pool = category.difficulties[diffKey];
+  return Array.isArray(pool) ? pool.slice() : [];
+}
+
+function shuffle(array) {
+  const arr = array.slice();
+  for (let i = arr.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+function getRandomQuestions(categoryId, difficulty, amount) {
+  const pool = getQuestionPool(categoryId, difficulty);
+  if (!pool.length) return [];
+  const limit = Number.isInteger(amount) ? Math.max(1, amount) : pool.length;
+  const shuffled = shuffle(pool);
+  return shuffled.slice(0, Math.min(limit, pool.length));
+}
+
+function formatDifficultyName(difficulty) {
+  const key = normaliseDifficultyKey(difficulty);
+  if (!key) return 'Unknown';
+  return key.charAt(0).toUpperCase() + key.slice(1);
+}
+
+module.exports = {
+  listCategories,
+  getCategory,
+  getQuestionPool,
+  getRandomQuestions,
+  normaliseDifficultyKey,
+  formatDifficultyName,
+  resetTriviaCache,
+};

--- a/src/utils/triviaGameManager.js
+++ b/src/utils/triviaGameManager.js
@@ -1,0 +1,449 @@
+const { EmbedBuilder, escapeMarkdown } = require('discord.js');
+const coinStore = require('./coinStore');
+const triviaData = require('./triviaData');
+const triviaStatsStore = require('./triviaStatsStore');
+
+const ROUND_DURATION_MS = 6_000;
+const DEFAULT_QUESTION_COUNT = 10;
+const BETWEEN_QUESTION_DELAY_MS = 1_500;
+
+const activeGames = new Map();
+
+function getKey(guildId, channelId) {
+  return `${guildId}:${channelId}`;
+}
+
+function formatPlayerName(profile, userId) {
+  if (profile) {
+    const name = profile.displayName || profile.globalName || profile.username;
+    if (name) return escapeMarkdown(name);
+  }
+  return `<@${userId}>`;
+}
+
+function ensurePlayer(game, userId, profile = null) {
+  let stats = game.players.get(userId);
+  if (!stats) {
+    stats = {
+      userId,
+      roundsParticipated: 0,
+      correctAnswers: 0,
+      firstCorrectAt: null,
+      lastCorrectAt: null,
+      profile: profile || null,
+      coinsAwarded: 0,
+      placement: null,
+    };
+    game.players.set(userId, stats);
+  }
+  if (profile) {
+    stats.profile = {
+      username: profile.username || stats.profile?.username || null,
+      displayName: profile.displayName || stats.profile?.displayName || null,
+      globalName: profile.globalName || stats.profile?.globalName || null,
+    };
+  }
+  return stats;
+}
+
+function parseAnswer(content) {
+  if (!content) return null;
+  const trimmed = content.trim().toUpperCase();
+  if (!trimmed) return null;
+  const match = /^([ABCD])\b/.exec(trimmed);
+  return match ? match[1] : null;
+}
+
+function formatChoices(question) {
+  const lines = [question.prompt, ''];
+  for (const letter of ['A', 'B', 'C', 'D']) {
+    const value = question.choices[letter];
+    if (!value) continue;
+    lines.push(`**${letter})** ${value}`);
+  }
+  lines.push('');
+  lines.push('_Answer with A, B, C, or D._');
+  return lines.join('\n');
+}
+
+function formatScoreboard(game, limit = 5) {
+  const players = Array.from(game.players.values())
+    .filter(player => player.correctAnswers > 0)
+    .sort((a, b) => {
+      if (b.correctAnswers !== a.correctAnswers) return b.correctAnswers - a.correctAnswers;
+      if (a.firstCorrectAt && b.firstCorrectAt) return a.firstCorrectAt - b.firstCorrectAt;
+      if (a.firstCorrectAt) return -1;
+      if (b.firstCorrectAt) return 1;
+      return a.userId.localeCompare(b.userId);
+    });
+
+  if (!players.length) return null;
+
+  const lines = players.slice(0, Math.max(1, limit)).map((player, index) => {
+    const accuracy = player.roundsParticipated > 0
+      ? Math.round((player.correctAnswers / player.roundsParticipated) * 100)
+      : 0;
+    const name = formatPlayerName(player.profile, player.userId);
+    const accuracyText = player.roundsParticipated > 0 ? ` (${accuracy}% accuracy)` : '';
+    return `${index + 1}. ${name} — ${player.correctAnswers} correct${accuracyText}`;
+  });
+
+  return lines.join('\n');
+}
+
+function wait(ms) {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function finishGame(game) {
+  const sortedPlayers = Array.from(game.players.values()).sort((a, b) => {
+    if (b.correctAnswers !== a.correctAnswers) return b.correctAnswers - a.correctAnswers;
+    if (a.firstCorrectAt && b.firstCorrectAt) return a.firstCorrectAt - b.firstCorrectAt;
+    if (a.firstCorrectAt) return -1;
+    if (b.firstCorrectAt) return 1;
+    return a.userId.localeCompare(b.userId);
+  });
+
+  const hasRounds = game.roundsPlayed > 0;
+
+  if (!hasRounds) {
+    await game.channel.send({
+      content: game.stopReason === 'error'
+        ? '⚠️ Trivia game ended unexpectedly before any questions were asked.'
+        : '⏹️ Trivia game ended before any questions were asked.',
+    }).catch(() => {});
+    return;
+  }
+
+  const topScoreEntry = sortedPlayers.find(player => player.correctAnswers > 0);
+  const topScore = topScoreEntry ? topScoreEntry.correctAnswers : 0;
+  const secondScoreEntry = sortedPlayers.find(player => player.correctAnswers > 0 && player.correctAnswers < topScore);
+  const secondScore = secondScoreEntry ? secondScoreEntry.correctAnswers : 0;
+
+  let placementsAssigned = 0;
+  let lastScore = null;
+  for (let i = 0; i < sortedPlayers.length; i += 1) {
+    const stats = sortedPlayers[i];
+    if (stats.correctAnswers <= 0) {
+      stats.placement = null;
+      continue;
+    }
+    if (lastScore === null || stats.correctAnswers !== lastScore) {
+      placementsAssigned = i + 1;
+      lastScore = stats.correctAnswers;
+    }
+    stats.placement = placementsAssigned;
+  }
+
+  const winners = topScore > 0
+    ? sortedPlayers.filter(player => player.correctAnswers === topScore)
+    : [];
+  const runnersUp = topScore > 0 && secondScore > 0
+    ? sortedPlayers.filter(player => player.correctAnswers === secondScore)
+    : [];
+
+  for (const player of winners) {
+    try {
+      await coinStore.addCoins(game.guildId, player.userId, 20);
+      player.coinsAwarded += 20;
+    } catch (err) {
+      console.error('Failed to award trivia winner coins:', err);
+    }
+  }
+
+  for (const player of runnersUp) {
+    try {
+      await coinStore.addCoins(game.guildId, player.userId, 10);
+      player.coinsAwarded += 10;
+      if (player.placement && player.placement > 2) {
+        player.placement = 2;
+      }
+    } catch (err) {
+      console.error('Failed to award trivia runner-up coins:', err);
+    }
+  }
+
+  const scoreboardFull = formatScoreboard(game, sortedPlayers.length);
+  const title = game.stopReason === 'error'
+    ? '⚠️ Trivia ended due to an error.'
+    : game.isStopped && game.roundsPlayed < game.questionCount
+      ? '⏹️ Trivia game ended early.'
+      : '🏁 Trivia finished!';
+
+  const rewardLines = [];
+  if (winners.length) {
+    const winnerNames = winners.map(player => formatPlayerName(player.profile, player.userId));
+    rewardLines.push(`🥇 ${winnerNames.join(', ')} +20 coins`);
+  }
+  if (runnersUp.length) {
+    const runnerNames = runnersUp.map(player => formatPlayerName(player.profile, player.userId));
+    rewardLines.push(`🥈 ${runnerNames.join(', ')} +10 coins`);
+  }
+  if (!rewardLines.length && topScore <= 0) {
+    rewardLines.push('No coins awarded — nobody answered a question correctly.');
+  }
+
+  const summaryLines = [
+    title,
+    `Category: **${game.categoryName}** (${game.difficultyLabel})`,
+    `Questions played: ${game.roundsPlayed} / ${game.questionCount}`,
+  ];
+  if (rewardLines.length) {
+    summaryLines.push('');
+    summaryLines.push(...rewardLines);
+  }
+  if (scoreboardFull) {
+    summaryLines.push('');
+    summaryLines.push('📊 **Final Standings**');
+    summaryLines.push(scoreboardFull);
+  }
+
+  await game.channel.send({ content: summaryLines.join('\n') }).catch(() => {});
+
+  const statsPayload = sortedPlayers
+    .filter(player => player.roundsParticipated > 0 || player.correctAnswers > 0)
+    .map(player => ({
+      userId: player.userId,
+      roundsParticipated: player.roundsParticipated,
+      correctAnswers: player.correctAnswers,
+      placement: player.placement,
+      coinsAwarded: player.coinsAwarded,
+    }));
+
+  triviaStatsStore.recordGame(game.guildId, {
+    categoryId: game.categoryId,
+    categoryName: game.categoryName,
+    difficulty: game.difficulty,
+    questionCount: game.roundsPlayed,
+    endedEarly: game.isStopped && game.roundsPlayed < game.questionCount,
+    players: statsPayload,
+  });
+}
+
+async function askQuestion(game, question, index) {
+  const embed = new EmbedBuilder()
+    .setColor(0x5865F2)
+    .setTitle(`Question ${index + 1} of ${game.questionCount}`)
+    .setDescription(formatChoices(question));
+
+  await game.channel.send({ embeds: [embed] }).catch(() => {});
+
+  const responses = new Map();
+
+  const collector = game.channel.createMessageCollector({
+    time: ROUND_DURATION_MS,
+    filter: message => {
+      if (message.author.bot) return false;
+      if (message.channelId !== game.channelId) return false;
+      return true;
+    },
+  });
+
+  game.currentCollector = collector;
+
+  collector.on('collect', message => {
+    if (game.isStopped) {
+      try { collector.stop('game-stopped'); } catch (_) {}
+      return;
+    }
+    if (responses.has(message.author.id)) return;
+    const choice = parseAnswer(message.content);
+    if (!choice) return;
+
+    const profile = {
+      username: message.author.username,
+      displayName: message.member?.displayName || null,
+      globalName: message.author.globalName || null,
+    };
+
+    const stats = ensurePlayer(game, message.author.id, profile);
+    stats.roundsParticipated += 1;
+
+    responses.set(message.author.id, {
+      choice,
+      timestamp: message.createdTimestamp || Date.now(),
+      profile,
+    });
+  });
+
+  await new Promise(resolve => {
+    collector.on('end', () => resolve());
+  });
+
+  game.currentCollector = null;
+
+  if (game.isStopped) return;
+
+  game.roundsPlayed += 1;
+
+  const correctChoice = question.answer;
+  const correctResponses = [];
+
+  for (const [userId, response] of responses.entries()) {
+    if (response.choice !== correctChoice) continue;
+    const stats = ensurePlayer(game, userId, response.profile);
+    stats.correctAnswers += 1;
+    stats.lastCorrectAt = response.timestamp;
+    if (!stats.firstCorrectAt) stats.firstCorrectAt = response.timestamp;
+    correctResponses.push({
+      userId,
+      profile: response.profile,
+      timestamp: response.timestamp,
+    });
+  }
+
+  correctResponses.sort((a, b) => a.timestamp - b.timestamp);
+
+  const answerText = question.choices[correctChoice];
+  const scoreboardText = formatScoreboard(game);
+
+  const resultLines = [
+    `🧠 **Answer:** ${correctChoice}) ${answerText}`,
+  ];
+
+  if (correctResponses.length) {
+    const winners = correctResponses.map(entry => formatPlayerName(entry.profile, entry.userId));
+    resultLines.push(`✅ ${winners.join(', ')} ${winners.length === 1 ? 'gets' : 'get'} a point!`);
+  } else {
+    resultLines.push('❌ Nobody answered correctly this round.');
+  }
+
+  if (scoreboardText) {
+    resultLines.push('');
+    resultLines.push('📊 **Standings**');
+    resultLines.push(scoreboardText);
+  }
+
+  await game.channel.send({ content: resultLines.join('\n') }).catch(() => {});
+}
+
+async function runTriviaGame(game) {
+  const introLines = [
+    '🎯 **Trivia starting!**',
+    `Category: **${game.categoryName}**`,
+    `Difficulty: **${game.difficultyLabel}**`,
+    `Questions: ${game.questionCount}`,
+    `Host: <@${game.hostId}>`,
+    '',
+    'Answer with **A**, **B**, **C**, or **D** within 6 seconds to earn points.',
+  ];
+
+  await game.channel.send({ content: introLines.join('\n') }).catch(() => {});
+
+  try {
+    for (let index = 0; index < game.questions.length; index += 1) {
+      if (game.isStopped) break;
+      // eslint-disable-next-line no-await-in-loop
+      await askQuestion(game, game.questions[index], index);
+      if (game.isStopped) break;
+      if (index < game.questions.length - 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await wait(BETWEEN_QUESTION_DELAY_MS);
+      }
+    }
+  } catch (err) {
+    console.error('Trivia game encountered an unexpected error:', err);
+    game.stopReason = 'error';
+    game.isStopped = true;
+  }
+
+  await finishGame(game);
+}
+
+async function startTriviaGame(interaction, options) {
+  const { categoryId, difficulty, questionCount } = options || {};
+  const difficultyKey = triviaData.normaliseDifficultyKey(difficulty);
+  if (!difficultyKey) {
+    return { ok: false, error: 'Invalid difficulty selected.' };
+  }
+
+  const category = triviaData.getCategory(categoryId);
+  if (!category) {
+    return { ok: false, error: 'That category could not be found.' };
+  }
+
+  const pool = category.difficulties[difficultyKey];
+  if (!pool || !pool.length) {
+    return { ok: false, error: 'There are no questions available for that difficulty yet.' };
+  }
+
+  const requested = Number.isInteger(questionCount) ? questionCount : DEFAULT_QUESTION_COUNT;
+  const actualCount = Math.max(1, Math.min(pool.length, requested));
+  const questions = triviaData.getRandomQuestions(categoryId, difficultyKey, actualCount);
+  if (!questions.length) {
+    return { ok: false, error: 'Failed to build the question list for this game.' };
+  }
+
+  const key = getKey(interaction.guildId, interaction.channelId);
+  if (activeGames.has(key)) {
+    const existing = activeGames.get(key);
+    return {
+      ok: false,
+      error: `A trivia game hosted by <@${existing.hostId}> is already running in this channel.`,
+    };
+  }
+
+  const channel = interaction.channel;
+  if (!channel || typeof channel.send !== 'function') {
+    return { ok: false, error: 'Unable to access the target channel.' };
+  }
+
+  const game = {
+    id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    guildId: interaction.guildId,
+    channelId: interaction.channelId,
+    channel,
+    hostId: interaction.user.id,
+    categoryId: category.id,
+    categoryName: category.name,
+    difficulty: difficultyKey,
+    difficultyLabel: triviaData.formatDifficultyName(difficultyKey),
+    questionCount: questions.length,
+    questions,
+    players: new Map(),
+    roundsPlayed: 0,
+    isStopped: false,
+    stopReason: null,
+    currentCollector: null,
+    startedAt: Date.now(),
+  };
+
+  game.stop = (reason) => {
+    if (game.isStopped) return;
+    game.isStopped = true;
+    game.stopReason = reason || 'stopped';
+    const collector = game.currentCollector;
+    if (collector) {
+      try { collector.stop('game-stopped'); } catch (_) {}
+    }
+  };
+
+  activeGames.set(key, game);
+
+  runTriviaGame(game).catch(err => {
+    console.error('Failed to run trivia game:', err);
+  }).finally(() => {
+    activeGames.delete(key);
+  });
+
+  return { ok: true, game, questionCount: questions.length };
+}
+
+function stopTriviaGame(guildId, channelId, reason = 'cancelled') {
+  const game = getActiveGame(guildId, channelId);
+  if (!game) return false;
+  game.stop(reason);
+  return true;
+}
+
+function getActiveGame(guildId, channelId) {
+  return activeGames.get(getKey(guildId, channelId)) || null;
+}
+
+module.exports = {
+  startTriviaGame,
+  stopTriviaGame,
+  getActiveGame,
+};

--- a/src/utils/triviaStatsStore.js
+++ b/src/utils/triviaStatsStore.js
@@ -1,0 +1,169 @@
+const fs = require('fs');
+const { ensureFileSync, writeJsonSync } = require('./dataDir');
+
+const STORE_FILE = 'trivia_stats.json';
+const DEFAULT_STORE = { guilds: {} };
+
+let cache = null;
+
+function loadStore() {
+  if (cache) return cache;
+  try {
+    const filePath = ensureFileSync(STORE_FILE, DEFAULT_STORE);
+    const raw = fs.readFileSync(filePath, 'utf8');
+    if (!raw) {
+      cache = { guilds: {} };
+    } else {
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== 'object') {
+        cache = { guilds: {} };
+      } else {
+        cache = parsed;
+        if (!cache.guilds || typeof cache.guilds !== 'object') cache.guilds = {};
+      }
+    }
+  } catch (err) {
+    console.error('Failed to load trivia stats store:', err);
+    cache = { guilds: {} };
+  }
+  return cache;
+}
+
+function saveStore() {
+  const store = loadStore();
+  const safe = store && typeof store === 'object' ? store : { guilds: {} };
+  if (!safe.guilds || typeof safe.guilds !== 'object') safe.guilds = {};
+  writeJsonSync(STORE_FILE, safe);
+}
+
+function getGuildEntry(guildId) {
+  const store = loadStore();
+  if (!store.guilds[guildId] || typeof store.guilds[guildId] !== 'object') {
+    store.guilds[guildId] = { players: {}, history: [] };
+  }
+  const entry = store.guilds[guildId];
+  if (!entry.players || typeof entry.players !== 'object') entry.players = {};
+  if (!Array.isArray(entry.history)) entry.history = [];
+  return entry;
+}
+
+function toNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : 0;
+}
+
+function recordGame(guildId, summary) {
+  if (!guildId || !summary || typeof summary !== 'object') return null;
+  const entry = getGuildEntry(guildId);
+  const now = Date.now();
+
+  const historyEntry = {
+    categoryId: summary.categoryId || null,
+    categoryName: summary.categoryName || null,
+    difficulty: summary.difficulty || null,
+    questions: toNumber(summary.questionCount),
+    finishedAt: now,
+    endedEarly: Boolean(summary.endedEarly),
+    players: Array.isArray(summary.players)
+      ? summary.players.map(player => ({
+        userId: player.userId,
+        placement: player.placement ?? null,
+        correctAnswers: toNumber(player.correctAnswers),
+        roundsParticipated: toNumber(player.roundsParticipated),
+        coinsAwarded: toNumber(player.coinsAwarded),
+      }))
+      : [],
+  };
+
+  entry.history.push(historyEntry);
+  if (entry.history.length > 50) entry.history.splice(0, entry.history.length - 50);
+
+  if (Array.isArray(summary.players)) {
+    for (const player of summary.players) {
+      const { userId } = player;
+      if (!userId) continue;
+      const stats = entry.players[userId] && typeof entry.players[userId] === 'object'
+        ? entry.players[userId]
+        : {
+          gamesPlayed: 0,
+          firstPlace: 0,
+          secondPlace: 0,
+          thirdPlace: 0,
+          roundsParticipated: 0,
+          correctAnswers: 0,
+          coinsEarned: 0,
+          bestScore: 0,
+          lastPlayedAt: 0,
+        };
+
+      const participated = toNumber(player.roundsParticipated);
+      const correct = toNumber(player.correctAnswers);
+      const placement = Number.isInteger(player.placement) ? player.placement : null;
+
+      if (participated <= 0 && correct <= 0) {
+        // Skip tracking players that never actively participated in the round.
+        continue;
+      }
+
+      stats.gamesPlayed += 1;
+      stats.roundsParticipated += participated;
+      stats.correctAnswers += correct;
+      stats.coinsEarned += toNumber(player.coinsAwarded);
+      if (correct > stats.bestScore) stats.bestScore = correct;
+      stats.lastPlayedAt = now;
+
+      if (placement === 1) stats.firstPlace += 1;
+      else if (placement === 2) stats.secondPlace += 1;
+      else if (placement === 3) stats.thirdPlace += 1;
+
+      entry.players[userId] = stats;
+    }
+  }
+
+  saveStore();
+  return historyEntry;
+}
+
+function getLeaderboard(guildId) {
+  if (!guildId) return [];
+  const entry = getGuildEntry(guildId);
+  const players = Object.entries(entry.players)
+    .map(([userId, stats]) => ({
+      userId,
+      gamesPlayed: toNumber(stats.gamesPlayed),
+      firstPlace: toNumber(stats.firstPlace),
+      secondPlace: toNumber(stats.secondPlace),
+      thirdPlace: toNumber(stats.thirdPlace),
+      roundsParticipated: toNumber(stats.roundsParticipated),
+      correctAnswers: toNumber(stats.correctAnswers),
+      coinsEarned: toNumber(stats.coinsEarned),
+      bestScore: toNumber(stats.bestScore),
+      lastPlayedAt: toNumber(stats.lastPlayedAt),
+    }))
+    .sort((a, b) => {
+      if (b.firstPlace !== a.firstPlace) return b.firstPlace - a.firstPlace;
+      if (b.secondPlace !== a.secondPlace) return b.secondPlace - a.secondPlace;
+      if (b.correctAnswers !== a.correctAnswers) return b.correctAnswers - a.correctAnswers;
+      if (b.gamesPlayed !== a.gamesPlayed) return b.gamesPlayed - a.gamesPlayed;
+      return b.lastPlayedAt - a.lastPlayedAt;
+    });
+  return players;
+}
+
+function getRecentGames(guildId, limit = 5) {
+  if (!guildId) return [];
+  const entry = getGuildEntry(guildId);
+  const games = Array.isArray(entry.history) ? entry.history.slice().reverse() : [];
+  return games.slice(0, Math.max(0, limit));
+}
+
+function resetStatsCache() {
+  cache = null;
+}
+
+module.exports = {
+  recordGame,
+  getLeaderboard,
+  getRecentGames,
+  resetStatsCache,
+};


### PR DESCRIPTION
## Summary
- add a trivia data loader and seed the Drugs and Narcotics category with easy/medium/hard questions
- implement a trivia game manager that runs timed rounds, scores players, awards coins, and records stats
- add slash commands to list trivia categories, start/stop games, and show historical rankings

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7a37b817883318c6104a124e67485