### PR TITLE
Allow configuring analysis response visibility

### DIFF
--- a/src/commands/analysis.js
+++ b/src/commands/analysis.js
@@ -134,6 +134,10 @@ module.exports = {
         { name: PERSONAS.default.label, value: PERSONAS.default.id },
         { name: PERSONAS.psychological.label, value: PERSONAS.psychological.id },
       )
+      .setRequired(false))
+    .addBooleanOption((option) => option
+      .setName('public')
+      .setDescription('Share the analysis in the channel instead of privately')
       .setRequired(false)),
 
   async execute(interaction) {
@@ -141,7 +145,10 @@ module.exports = {
       return interaction.reply({ content: 'Use this command inside a server.', ephemeral: true });
     }
 
-    try { await interaction.deferReply({ ephemeral: true }); } catch (_) {}
+    const wantsPublicReply = interaction.options.getBoolean('public');
+    const ephemeral = wantsPublicReply !== true;
+
+    try { await interaction.deferReply({ ephemeral }); } catch (_) {}
 
     if (!OPENAI_API_KEY) {
       return interaction.editReply({ content: 'OpenAI API key not configured. Set OPENAI_API_KEY to enable /analysis.' });


### PR DESCRIPTION
## Summary
- add an optional `public` flag to `/analysis` so users can share responses in-channel
- default to private responses by deferring replies ephemerally unless the user opts in

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7ae5b2750833180fe70c34ad08bc6