### PR TITLE
Add ban sync and cross-server lookup commands

### DIFF
--- a/src/commands/bannedfrom.js
+++ b/src/commands/bannedfrom.js
@@ -1,0 +1,48 @@
+const { SlashCommandBuilder, PermissionsBitField, EmbedBuilder } = require('discord.js');
+const banStore = require('../utils/banStore');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('bannedfrom')
+    .setDescription('Check if a user is banned in other servers where the bot is present.')
+    .addUserOption(opt =>
+      opt
+        .setName('user')
+        .setDescription('User to look up')
+        .setRequired(true)
+    ),
+
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ content: 'Use this command in a server.', ephemeral: true });
+    }
+
+    if (!interaction.member.permissions?.has(PermissionsBitField.Flags.ManageGuild)) {
+      return interaction.reply({ content: 'You need the Manage Server permission to use this command.', ephemeral: true });
+    }
+
+    await interaction.deferReply({ ephemeral: true });
+
+    const target = interaction.options.getUser('user', true);
+    const bans = banStore.getUserBans(target.id, { excludeGuildId: interaction.guildId });
+
+    if (!bans.length) {
+      return interaction.editReply({ content: `${target.tag} is not recorded as banned in other servers that synced with /showbans.` });
+    }
+
+    const embed = new EmbedBuilder()
+      .setTitle(`Ban history for ${target.tag}`)
+      .setColor(0xff0000);
+
+    const lines = bans.map(entry => {
+      const guildName = entry.guildName || entry.guildId;
+      const reason = entry.reason ? entry.reason.slice(0, 200) : 'No reason provided';
+      const synced = entry.syncedAt ? `<t:${Math.floor(entry.syncedAt / 1000)}:R>` : 'Unknown time';
+      return `• **${guildName}** — ${reason} (synced ${synced})`;
+    });
+
+    embed.setDescription(lines.join('\n'));
+
+    return interaction.editReply({ embeds: [embed] });
+  },
+};

--- a/src/commands/showbans.js
+++ b/src/commands/showbans.js
@@ -1,0 +1,62 @@
+const { SlashCommandBuilder, PermissionsBitField, EmbedBuilder } = require('discord.js');
+const banStore = require('../utils/banStore');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('showbans')
+    .setDescription('List current bans in this server and cache them for cross-server checks.'),
+
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ content: 'Use this command in a server.', ephemeral: true });
+    }
+
+    if (!interaction.member.permissions?.has(PermissionsBitField.Flags.BanMembers)) {
+      return interaction.reply({ content: 'You need the Ban Members permission to use this command.', ephemeral: true });
+    }
+
+    await interaction.deferReply({ ephemeral: true });
+
+    const me = interaction.guild.members.me;
+    if (!me?.permissions?.has(PermissionsBitField.Flags.BanMembers)) {
+      return interaction.editReply({ content: 'I need the Ban Members permission to read ban data.' });
+    }
+
+    let bans;
+    try {
+      bans = await interaction.guild.bans.fetch();
+    } catch (err) {
+      return interaction.editReply({ content: `Failed to fetch bans: ${err.message || 'Unknown error'}` });
+    }
+
+    const records = bans.map(ban => ({
+      userId: ban.user.id,
+      reason: ban.reason || null,
+      tag: typeof ban.user.tag === 'string' ? ban.user.tag : null,
+    }));
+
+    banStore.setGuildBans(interaction.guild.id, interaction.guild.name, records);
+
+    if (!records.length) {
+      return interaction.editReply({ content: 'No members are currently banned.' });
+    }
+
+    const limit = 25;
+    const first = records.slice(0, limit);
+    const lines = first.map((ban, index) => {
+      const tag = ban.tag || `Unknown (${ban.userId})`;
+      const reason = ban.reason ? ban.reason.slice(0, 200) : 'No reason provided';
+      return `${index + 1}. ${tag} — ${reason}`;
+    });
+
+    const extra = records.length > limit ? `\n…and ${records.length - limit} more.` : '';
+    const embed = new EmbedBuilder()
+      .setTitle(`Banned members in ${interaction.guild.name}`)
+      .setDescription(`${lines.join('\n')}${extra}`)
+      .setColor(0xff0000)
+      .setFooter({ text: `Synced ${records.length} ban(s)` })
+      .setTimestamp();
+
+    return interaction.editReply({ embeds: [embed] });
+  },
+};

--- a/src/utils/banStore.js
+++ b/src/utils/banStore.js
@@ -1,0 +1,92 @@
+const fs = require('fs');
+const { ensureFileSync, writeJsonSync, resolveDataPath } = require('./dataDir');
+
+const STORE_FILE = 'bans.json';
+
+let cache = null;
+
+function load() {
+  if (cache) return cache;
+  try {
+    ensureFileSync(STORE_FILE, { guilds: {} });
+    const file = resolveDataPath(STORE_FILE);
+    if (fs.existsSync(file)) {
+      const raw = fs.readFileSync(file, 'utf8');
+      cache = raw ? JSON.parse(raw) : { guilds: {} };
+    } else {
+      cache = { guilds: {} };
+    }
+  } catch (err) {
+    console.error('Failed to load ban store:', err);
+    cache = { guilds: {} };
+  }
+  if (!cache.guilds || typeof cache.guilds !== 'object') cache.guilds = {};
+  return cache;
+}
+
+function save() {
+  if (!cache || typeof cache !== 'object') cache = { guilds: {} };
+  if (!cache.guilds || typeof cache.guilds !== 'object') cache.guilds = {};
+  writeJsonSync(STORE_FILE, cache);
+}
+
+function setGuildBans(guildId, guildName, bans) {
+  const store = load();
+  const now = Date.now();
+  const entries = {};
+  for (const ban of bans) {
+    if (!ban || !ban.userId) continue;
+    entries[ban.userId] = {
+      userId: ban.userId,
+      reason: ban.reason || null,
+      tag: ban.tag || null,
+      syncedAt: now,
+    };
+  }
+  store.guilds[guildId] = {
+    guildId,
+    guildName: guildName || null,
+    syncedAt: now,
+    bans: entries,
+  };
+  save();
+}
+
+function getGuildBans(guildId) {
+  const store = load();
+  const guild = store.guilds?.[guildId];
+  if (!guild || !guild.bans) return [];
+  return Object.values(guild.bans).map(entry => ({
+    userId: entry.userId,
+    reason: entry.reason || null,
+    tag: entry.tag || null,
+    syncedAt: entry.syncedAt || guild.syncedAt || null,
+  }));
+}
+
+function getUserBans(userId, { excludeGuildId } = {}) {
+  const store = load();
+  const results = [];
+  if (!store.guilds || typeof store.guilds !== 'object') return results;
+  for (const [guildId, data] of Object.entries(store.guilds)) {
+    if (!data || typeof data !== 'object') continue;
+    if (excludeGuildId && guildId === excludeGuildId) continue;
+    const entry = data.bans?.[userId];
+    if (!entry) continue;
+    results.push({
+      guildId,
+      guildName: data.guildName || guildId,
+      reason: entry.reason || null,
+      tag: entry.tag || null,
+      syncedAt: entry.syncedAt || data.syncedAt || null,
+    });
+  }
+  results.sort((a, b) => (b.syncedAt || 0) - (a.syncedAt || 0));
+  return results;
+}
+
+module.exports = {
+  setGuildBans,
+  getGuildBans,
+  getUserBans,
+};


### PR DESCRIPTION
## Summary
- add a /showbans admin command that lists current bans and stores them per guild
- add a /bannedfrom command so admins can query cross-server ban data when the bot is present
- persist ban snapshots in a new utility store for reuse across commands

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7b88cf0948331b4e310f34f4b5ec8