### PR TITLE
Respect guild embed colour preferences

### DIFF
--- a/src/commands/adminlist.js
+++ b/src/commands/adminlist.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, PermissionsBitField, EmbedBuilder } = require('discord.js');
 const { isOwner } = require('../utils/ownerIds');
+const { resolveEmbedColour } = require('../utils/guildColourStore');
 
 function sleep(ms) { return new Promise(res => setTimeout(res, ms)); }
 
@@ -53,7 +54,7 @@ module.exports = {
 
     const embed = new EmbedBuilder()
       .setTitle('Admin Guilds Report')
-      .setColor(0x0000ff)
+      .setColor(resolveEmbedColour(interaction.guildId, 0x0000ff))
       .addFields(
         { name: 'User', value: `${user.tag} (${user.id})`, inline: false },
         { name: 'Total admin guilds (mutual)', value: String(adminGuilds.length), inline: true },

--- a/src/commands/analysis.js
+++ b/src/commands/analysis.js
@@ -3,6 +3,7 @@ const judgementStore = require('../utils/judgementStore');
 const messageLogStore = require('../utils/userMessageLogStore');
 const coinStore = require('../utils/coinStore');
 const { getJudgementCost } = require('../utils/economyConfig');
+const { resolveEmbedColour } = require('../utils/guildColourStore');
 
 const fetch = (...args) => import('node-fetch').then(({ default: fetchImpl }) => fetchImpl(...args));
 
@@ -85,7 +86,7 @@ function formatMessages(logs, targetCount) {
 function buildEmbed(interaction, analysis, count) {
   const embed = new EmbedBuilder()
     .setTitle('User Analysis')
-    .setColor(0x5865f2)
+    .setColor(resolveEmbedColour(interaction.guildId, 0x5865f2))
     .setDescription(`Review of ${interaction.user.tag} (${interaction.user.id})\nMessages analysed: ${count}`)
     .setTimestamp(new Date());
 

--- a/src/commands/avatar.js
+++ b/src/commands/avatar.js
@@ -1,4 +1,5 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { resolveEmbedColour } = require('../utils/guildColourStore');
 
 function buildAvatarLinks(user) {
   const size = 4096;
@@ -33,7 +34,7 @@ module.exports = {
       .setTitle(`${target.tag || target.username}'s avatar`)
       .setDescription(links)
       .setImage(displayUrl)
-      .setColor(0x5865F2)
+      .setColor(resolveEmbedColour(interaction.guildId, 0x5865F2))
       .setFooter({ text: `Requested by ${interaction.user.tag || interaction.user.username}` })
       .setTimestamp(Date.now());
 

--- a/src/commands/avatarhistory.js
+++ b/src/commands/avatarhistory.js
@@ -1,4 +1,5 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { resolveEmbedColour } = require('../utils/guildColourStore');
 // node-fetch v3 is ESM-only; use dynamic import in CommonJS
 const fetch = (...args) => import('node-fetch').then(({ default: fetch }) => fetch(...args));
 
@@ -73,7 +74,7 @@ module.exports = {
         .setTitle(`${target.tag || target.username}'s recent avatars`)
         .setDescription(lines.join('\n'))
         .setThumbnail(target.displayAvatarURL({ size: 256 }))
-        .setColor(0x5865F2);
+        .setColor(resolveEmbedColour(interaction.guildId, 0x5865F2));
 
       await interaction.editReply({
         content: null,

--- a/src/commands/bannedfrom.js
+++ b/src/commands/bannedfrom.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, PermissionsBitField, EmbedBuilder } = require('discord.js');
 const banStore = require('../utils/banStore');
+const { resolveEmbedColour } = require('../utils/guildColourStore');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -32,7 +33,7 @@ module.exports = {
 
     const embed = new EmbedBuilder()
       .setTitle(`Ban history for ${target.tag}`)
-      .setColor(0xff0000);
+      .setColor(resolveEmbedColour(interaction.guildId, 0xff0000));
 
     const lines = bans.map(entry => {
       const guildName = entry.guildName || entry.guildId;

--- a/src/commands/botinfo.js
+++ b/src/commands/botinfo.js
@@ -1,4 +1,5 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { resolveEmbedColour } = require('../utils/guildColourStore');
 
 function formatUptime(ms) {
   const sec = Math.floor(ms / 1000) % 60;
@@ -28,7 +29,7 @@ module.exports = {
 
     const embed = new EmbedBuilder()
       .setTitle('Bot Info')
-      .setColor('#0000ff')
+      .setColor(resolveEmbedColour(interaction.guildId, 0x0000ff))
       .addFields(
         { name: 'Bot', value: `${user.tag} (${user.id})`, inline: false },
         { name: 'Application ID', value: appId, inline: false },

--- a/src/commands/dmdiag.js
+++ b/src/commands/dmdiag.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder, PermissionsBitField, EmbedBuilder } = require('discord.js');
 const logger = require('../utils/securityLogger');
 const { isOwner } = require('../utils/ownerIds');
+const { resolveEmbedColour } = require('../utils/guildColourStore');
 
 function sleep(ms) { return new Promise(res => setTimeout(res, ms)); }
 
@@ -96,7 +97,7 @@ module.exports = {
 
       const embed = new EmbedBuilder()
         .setTitle('DM Diagnostic Report')
-        .setColor(0x0000ff)
+        .setColor(resolveEmbedColour(interaction.guildId, 0x0000ff))
         .setDescription(`Role: ${role} • Checked: ${list.length}\nSuccess: ${ok} • Fail: ${fail}`)
         .setTimestamp(new Date());
       if (failed.length) {

--- a/src/commands/horseracestandings.js
+++ b/src/commands/horseracestandings.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder, escapeMarkdown } = require('discord.js');
 const { getLeaderboard, getStatsForGuild } = require('../utils/horseRaceStore');
+const { resolveEmbedColour } = require('../utils/guildColourStore');
 
 const PLACE_EMOJIS = ['🥇', '🥈', '🥉'];
 
@@ -65,7 +66,7 @@ module.exports = {
 
     const embed = new EmbedBuilder()
       .setTitle('🏇 Horse Race Standings')
-      .setColor(0x5865f2)
+      .setColor(resolveEmbedColour(interaction.guildId, 0x5865f2))
       .setDescription(lines.join('\n'))
       .setFooter({ text: 'Standings are sorted by golds, then silvers, bronzes, and races.' });
 

--- a/src/commands/inventory.js
+++ b/src/commands/inventory.js
@@ -3,6 +3,7 @@ const coinStore = require('../utils/coinStore');
 const tokenStore = require('../utils/messageTokenStore');
 const judgementStore = require('../utils/judgementStore');
 const smiteConfigStore = require('../utils/smiteConfigStore');
+const { resolveEmbedColour } = require('../utils/guildColourStore');
 const {
   getSmiteCost,
   getJudgementCost,
@@ -29,6 +30,7 @@ function formatDuration(ms) {
 }
 
 function buildInventoryEmbed({
+  guildId,
   user,
   coinSummary,
   smiteBalance,
@@ -45,7 +47,7 @@ function buildInventoryEmbed({
   const title = username ? `${username}'s Divine Inventory` : 'Your Divine Inventory';
 
   const embed = new EmbedBuilder()
-    .setColor(0xf1c40f)
+    .setColor(resolveEmbedColour(guildId, 0xf1c40f))
     .setTitle(title)
     .setDescription(
       'Your sacred belongings, tallied and catalogued. Spend coins in /store to expand your arsenal.'
@@ -119,6 +121,7 @@ module.exports = {
     const prayReward = getPrayReward();
 
     const embed = buildInventoryEmbed({
+      guildId,
       user: interaction.user,
       coinSummary,
       smiteBalance,

--- a/src/commands/jail.js
+++ b/src/commands/jail.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, PermissionsBitField, EmbedBuilder, ChannelType } = require('discord.js');
 const store = require('../utils/jailStore');
+const { resolveEmbedColour } = require('../utils/guildColourStore');
 
 function parseDuration(str) {
   if (!str) return null;
@@ -228,7 +229,7 @@ module.exports = {
 
       const embed = new EmbedBuilder()
         .setTitle('Member Jailed')
-        .setColor(0xff0000)
+        .setColor(resolveEmbedColour(interaction.guildId, 0xff0000))
         .setDescription(`${member.user.tag} has been jailed.`)
         .addFields(
           { name: 'Reason', value: reason, inline: false },

--- a/src/commands/joins.js
+++ b/src/commands/joins.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder, EmbedBuilder, PermissionsBitField, ChannelType } = require('discord.js');
 const store = require('../utils/joinLeaveStore');
 const cfgStore = require('../utils/joinLogConfigStore');
+const { resolveEmbedColour } = require('../utils/guildColourStore');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -78,7 +79,10 @@ module.exports = {
       }));
 
       const title = type === 'leave' ? 'Top Leaves' : type === 'join' ? 'Top Joins' : 'Top Joins/Leaves (Total)';
-      const embed = new EmbedBuilder().setTitle(title).setColor(0x0000ff).setDescription(lines.join('\n'));
+      const embed = new EmbedBuilder()
+        .setTitle(title)
+        .setColor(resolveEmbedColour(interaction.guildId, 0x0000ff))
+        .setDescription(lines.join('\n'));
       if (days) embed.setFooter({ text: `Window: last ${days} day(s)` });
       return interaction.editReply({ embeds: [embed] });
     }
@@ -90,7 +94,7 @@ module.exports = {
       const stats = store.getUserStats(interaction.guildId, member.id, sinceMs);
       const embed = new EmbedBuilder()
         .setTitle(`Join/Leave Stats — ${member.tag}`)
-        .setColor(0x0000ff)
+        .setColor(resolveEmbedColour(interaction.guildId, 0x0000ff))
         .addFields(
           { name: 'Joins', value: String(stats.joins || 0), inline: true },
           { name: 'Leaves', value: String(stats.leaves || 0), inline: true },

--- a/src/commands/securityreport.js
+++ b/src/commands/securityreport.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder, PermissionFlagsBits } = require('discord.js');
 const eventsStore = require('../utils/securityEventsStore');
+const { resolveEmbedColour } = require('../utils/guildColourStore');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -48,7 +49,7 @@ module.exports = {
 
     const embed = new EmbedBuilder()
       .setTitle('Security Report')
-      .setColor(0x0000ff)
+      .setColor(resolveEmbedColour(interaction.guildId, 0x0000ff))
       .setDescription(lines.join('\n'))
       .setFooter({ text: `Type: ${type} • Window: ${days}d • Total unique: ${rows.length}` })
       .setTimestamp(new Date());

--- a/src/commands/serverbanner.js
+++ b/src/commands/serverbanner.js
@@ -1,4 +1,5 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { resolveEmbedColour } = require('../utils/guildColourStore');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -29,7 +30,7 @@ module.exports = {
       .setTitle(`${guild.name} server banner`)
       .setDescription(links)
       .setImage(banner)
-      .setColor(0x5865F2)
+      .setColor(resolveEmbedColour(interaction.guildId, 0x5865F2))
       .setTimestamp(Date.now());
 
     await interaction.reply({ embeds: [embed] });

--- a/src/commands/serverlogo.js
+++ b/src/commands/serverlogo.js
@@ -1,4 +1,5 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { resolveEmbedColour } = require('../utils/guildColourStore');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -29,7 +30,7 @@ module.exports = {
       .setTitle(`${guild.name} server icon`)
       .setDescription(links)
       .setImage(icon)
-      .setColor(0x5865F2)
+      .setColor(resolveEmbedColour(interaction.guildId, 0x5865F2))
       .setTimestamp(Date.now());
 
     await interaction.reply({ embeds: [embed] });

--- a/src/commands/showbans.js
+++ b/src/commands/showbans.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, PermissionsBitField, EmbedBuilder } = require('discord.js');
 const banStore = require('../utils/banStore');
+const { resolveEmbedColour } = require('../utils/guildColourStore');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -53,7 +54,7 @@ module.exports = {
     const embed = new EmbedBuilder()
       .setTitle(`Banned members in ${interaction.guild.name}`)
       .setDescription(`${lines.join('\n')}${extra}`)
-      .setColor(0xff0000)
+      .setColor(resolveEmbedColour(interaction.guildId, 0xff0000))
       .setFooter({ text: `Synced ${records.length} ban(s)` })
       .setTimestamp();
 

--- a/src/commands/store.js
+++ b/src/commands/store.js
@@ -10,6 +10,7 @@ const tokenStore = require('../utils/messageTokenStore');
 const judgementStore = require('../utils/judgementStore');
 const smiteConfigStore = require('../utils/smiteConfigStore');
 const { getSmiteCost, getJudgementCost } = require('../utils/economyConfig');
+const { resolveEmbedColour } = require('../utils/guildColourStore');
 
 function formatCoins(value) {
   return Number(value).toLocaleString(undefined, {
@@ -19,6 +20,7 @@ function formatCoins(value) {
 }
 
 function buildStoreEmbed({
+  guildId,
   user,
   coins,
   smiteBalance,
@@ -28,7 +30,7 @@ function buildStoreEmbed({
   smiteEnabled,
 }) {
   const embed = new EmbedBuilder()
-    .setColor(0x9b59b6)
+    .setColor(resolveEmbedColour(guildId, 0x9b59b6))
     .setTitle('Divine Storefront')
     .setDescription('Spend your celestial coins on powerful blessings and punishments.')
     .addFields(
@@ -149,6 +151,7 @@ module.exports = {
     let message = await interaction.editReply({
       embeds: [
         buildStoreEmbed({
+          guildId,
           user: interaction.user,
           coins,
           smiteBalance,
@@ -199,6 +202,7 @@ module.exports = {
           message = await selection.update({
             embeds: [
               buildStoreEmbed({
+                guildId,
                 user: interaction.user,
                 coins,
                 smiteBalance: updatedSmiteBalance,

--- a/src/commands/summarize.js
+++ b/src/commands/summarize.js
@@ -199,6 +199,7 @@ module.exports = {
 
       const sections = buildSummarySections(out);
       const embeds = createFieldEmbeds({
+        guildId: interaction.guildId,
         title: 'Channel Summary',
         user: interaction.user,
         description: truncatedNote ? truncatedNote.trim() : undefined,

--- a/src/commands/transcribe.js
+++ b/src/commands/transcribe.js
@@ -36,6 +36,7 @@ module.exports = {
     try {
       const text = await transcribeAttachment(attachment, prompt);
       const embeds = createFieldEmbeds({
+        guildId: interaction.guildId,
         title: 'Transcript',
         user: interaction.user,
         sections: [

--- a/src/commands/triviacategories.js
+++ b/src/commands/triviacategories.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const triviaData = require('../utils/triviaData');
+const { resolveEmbedColour } = require('../utils/guildColourStore');
 
 function formatCategoryLine(category) {
   const description = category.description
@@ -33,6 +34,7 @@ module.exports = {
     }
 
     const lines = categories.map(formatCategoryLine);
+    const embedColor = resolveEmbedColour(interaction.guildId, 0x5865F2);
     const embeds = [];
     let buffer = '';
 
@@ -40,7 +42,7 @@ module.exports = {
       const next = buffer ? `${buffer}\n\n${line}` : line;
       if (next.length > 3800 && buffer) {
         embeds.push(new EmbedBuilder()
-          .setColor(0x5865F2)
+          .setColor(embedColor)
           .setTitle('Trivia Categories')
           .setDescription(buffer)
           .setFooter({ text: 'Use /triviastart to begin a game in your favourite category.' }));
@@ -52,7 +54,7 @@ module.exports = {
 
     if (buffer) {
       embeds.push(new EmbedBuilder()
-        .setColor(0x5865F2)
+        .setColor(embedColor)
         .setTitle('Trivia Categories')
         .setDescription(buffer)
         .setFooter({ text: 'Use /triviastart to begin a game in your favourite category.' }));

--- a/src/commands/triviarankings.js
+++ b/src/commands/triviarankings.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, EmbedBuilder, escapeMarkdown } = require('discord.js');
 const triviaStatsStore = require('../utils/triviaStatsStore');
+const { resolveEmbedColour } = require('../utils/guildColourStore');
 
 async function resolveDisplayName(guild, userId) {
   if (!guild) return `User ${userId}`;
@@ -66,7 +67,7 @@ module.exports = {
     const lines = resolved.map(entry => formatLeaderboardLine(entry, entry.index));
 
     const embed = new EmbedBuilder()
-      .setColor(0x5865F2)
+      .setColor(resolveEmbedColour(interaction.guildId, 0x5865F2))
       .setTitle('Trivia Leaderboard')
       .setDescription(lines.join('\n'))
       .setFooter({ text: 'Wins grant +20 coins and runners-up earn +10 coins.' });

--- a/src/events/messageDelete.js
+++ b/src/events/messageDelete.js
@@ -1,6 +1,7 @@
 const { Events, AuditLogEvent, PermissionsBitField, EmbedBuilder } = require('discord.js');
 const store = require('../utils/logChannelsStore');
 const { parseOwnerIds } = require('../utils/ownerIds');
+const { resolveEmbedColour } = require('../utils/guildColourStore');
 
 module.exports = {
   name: Events.MessageDelete,
@@ -67,7 +68,7 @@ module.exports = {
       ];
       const embed = new EmbedBuilder()
         .setTitle('Admin deleted a message in a monitored log channel')
-        .setColor(0x0000ff)
+        .setColor(resolveEmbedColour(guild.id, 0x0000ff))
         .setTimestamp(new Date())
         .addFields(fields);
 

--- a/src/events/voiceTranscribe.js
+++ b/src/events/voiceTranscribe.js
@@ -29,6 +29,7 @@ module.exports = {
 
       const text = await transcribeAttachment(attachment);
       const embeds = createFieldEmbeds({
+        guildId: message.guildId,
         title: 'Voice Transcript',
         user: message.author,
         sections: [

--- a/src/utils/embedFields.js
+++ b/src/utils/embedFields.js
@@ -1,4 +1,5 @@
 const { EmbedBuilder } = require('discord.js');
+const { resolveEmbedColour } = require('./guildColourStore');
 
 const DEFAULT_COLOR = 0x5865F2;
 const FIELD_CHUNK_SIZE = 1024;
@@ -20,7 +21,8 @@ function createFieldEmbeds({
   sections,
   user,
   description,
-  color = DEFAULT_COLOR,
+  guildId,
+  color = null,
   inline = false,
 }) {
   if (!Array.isArray(sections) || !sections.length) return [];
@@ -56,8 +58,9 @@ function createFieldEmbeds({
   const startNewEmbed = () => {
     const suffix = embedIndex === 0 ? '' : ` (cont. ${embedIndex})`;
     const computedTitle = title ? `${title}${suffix}` : null;
+    const resolvedColor = color ?? resolveEmbedColour(guildId, DEFAULT_COLOR);
     currentEmbed = new EmbedBuilder()
-      .setColor(color);
+      .setColor(resolvedColor);
     if (computedTitle) {
       currentEmbed.setTitle(computedTitle);
     }

--- a/src/utils/guildColourStore.js
+++ b/src/utils/guildColourStore.js
@@ -57,11 +57,24 @@ function toHex6(colourNum) {
   return `#${Number(colourNum).toString(16).padStart(6, '0').toUpperCase()}`;
 }
 
-function getDefaultColour(guildId) {
+function getStoredColour(guildId) {
   const store = readStore();
   const rec = store.guilds[guildId];
-  if (!rec || typeof rec.colour !== 'number') return DEFAULT_EMBED_COLOUR;
+  if (!rec || typeof rec.colour !== 'number') return null;
   return rec.colour;
+}
+
+function getDefaultColour(guildId) {
+  const stored = getStoredColour(guildId);
+  if (typeof stored === 'number') return stored;
+  return DEFAULT_EMBED_COLOUR;
+}
+
+function resolveEmbedColour(guildId, fallback = DEFAULT_EMBED_COLOUR) {
+  const stored = getStoredColour(guildId);
+  if (typeof stored === 'number') return stored;
+  if (typeof fallback === 'number') return fallback;
+  return DEFAULT_EMBED_COLOUR;
 }
 
 async function setDefaultColour(guildId, input) {
@@ -92,7 +105,9 @@ module.exports = {
   DEFAULT_EMBED_COLOUR,
   parseColour,
   toHex6,
+  getStoredColour,
   getDefaultColour,
+  resolveEmbedColour,
   setDefaultColour,
   applyDefaultColour,
 };

--- a/src/utils/modLogger.js
+++ b/src/utils/modLogger.js
@@ -1,6 +1,7 @@
 const { EmbedBuilder } = require('discord.js');
 const store = require('./modLogStore');
 const { parseOwnerIds } = require('./ownerIds');
+const { resolveEmbedColour } = require('./guildColourStore');
 
 async function send(interaction, embed) {
   const guild = interaction.guild;
@@ -67,7 +68,8 @@ function baseEmbed(interaction, title, color = 0x5865f2) {
   ];
   if (guild) fields.unshift({ name: 'Guild', value: `${guild.name} (${guild.id})`, inline: false });
   if (interaction.channel) fields.push({ name: 'Channel', value: `<#${interaction.channel.id}> (${interaction.channel.id})`, inline: false });
-  return new EmbedBuilder().setTitle(title).setColor(color).setTimestamp(new Date()).addFields(fields);
+  const resolvedColor = resolveEmbedColour(interaction.guildId, color);
+  return new EmbedBuilder().setTitle(title).setColor(resolvedColor).setTimestamp(new Date()).addFields(fields);
 }
 
 async function log(interaction, title, extraFields = [], color) {

--- a/src/utils/securityLogger.js
+++ b/src/utils/securityLogger.js
@@ -2,6 +2,7 @@ const { EmbedBuilder, PermissionsBitField } = require('discord.js');
 const logStore = require('./securityLogStore');
 const eventsStore = require('./securityEventsStore');
 const { parseOwnerIds } = require('./ownerIds');
+const { resolveEmbedColour } = require('./guildColourStore');
 
 async function sendEmbedToOwners(client, embed) {
   const owners = parseOwnerIds();
@@ -98,9 +99,10 @@ function baseEmbed(interaction, title, color = 0xffaa00) {
   ];
   if (guild) fields.unshift({ name: 'Guild', value: `${guild.name} (${guild.id})`, inline: false });
   if (interaction.channel) fields.push({ name: 'Channel', value: `<#${interaction.channel.id}> (${interaction.channel.id})`, inline: false });
+  const resolvedColor = resolveEmbedColour(interaction.guildId, color);
   return new EmbedBuilder()
     .setTitle(title)
-    .setColor(color)
+    .setColor(resolvedColor)
     .setTimestamp(new Date())
     .addFields(fields);
 }

--- a/src/utils/triviaGameManager.js
+++ b/src/utils/triviaGameManager.js
@@ -2,6 +2,7 @@ const { EmbedBuilder, escapeMarkdown } = require('discord.js');
 const coinStore = require('./coinStore');
 const triviaData = require('./triviaData');
 const triviaStatsStore = require('./triviaStatsStore');
+const { resolveEmbedColour } = require('./guildColourStore');
 
 const ROUND_DURATION_MS = 6_000;
 const DEFAULT_QUESTION_COUNT = 10;
@@ -224,7 +225,7 @@ async function finishGame(game) {
 
 async function askQuestion(game, question, index) {
   const embed = new EmbedBuilder()
-    .setColor(0x5865F2)
+    .setColor(resolveEmbedColour(game.guildId, 0x5865F2))
     .setTitle(`Question ${index + 1} of ${game.questionCount}`)
     .setDescription(formatChoices(question));
 


### PR DESCRIPTION
## Summary
- add helper utilities to resolve per-guild embed colours with stored overrides
- apply the resolved colour across commands, events, and logging helpers so responses honour server branding

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7c763a780833194e052e981a874d2