### PR TITLE
Add /font command for stylized text output

### DIFF
--- a/src/commands/font.js
+++ b/src/commands/font.js
@@ -1,0 +1,49 @@
+const { SlashCommandBuilder } = require('discord.js');
+const { fontChoices, transformWithFont } = require('../utils/fontStyles');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('font')
+    .setDescription('Render your text using a decorative font style.')
+    .addStringOption(option =>
+      option
+        .setName('style')
+        .setDescription('Font style to apply to your message')
+        .setRequired(true)
+        .setChoices(...fontChoices)
+    )
+    .addStringOption(option =>
+      option
+        .setName('message')
+        .setDescription('The message to render in the selected font')
+        .setRequired(true)
+    ),
+
+  async execute(interaction) {
+    const style = interaction.options.getString('style', true);
+    const message = interaction.options.getString('message', true);
+
+    let stylized;
+    try {
+      stylized = transformWithFont(message, style);
+    } catch (error) {
+      return interaction.reply({
+        content: 'That font style is not available right now. Please pick a different option.',
+        ephemeral: true,
+      });
+    }
+
+    if (stylized.length === 0) {
+      return interaction.reply({ content: 'Please provide a message to transform.', ephemeral: true });
+    }
+
+    if (stylized.length > 2000) {
+      return interaction.reply({
+        content: 'The transformed message is too long to send. Try a shorter message.',
+        ephemeral: true,
+      });
+    }
+
+    return interaction.reply({ content: stylized, allowedMentions: { parse: [] } });
+  },
+};

--- a/src/utils/fontStyles.js
+++ b/src/utils/fontStyles.js
@@ -1,0 +1,82 @@
+const baseLower = 'abcdefghijklmnopqrstuvwxyz';
+const baseUpper = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const baseDigits = '0123456789';
+
+function createSequentialFont(key, label, codepoints) {
+  const mapping = {};
+
+  if (typeof codepoints.lowerStart === 'number') {
+    for (let i = 0; i < baseLower.length; i += 1) {
+      mapping[baseLower[i]] = String.fromCodePoint(codepoints.lowerStart + i);
+    }
+  }
+
+  if (typeof codepoints.upperStart === 'number') {
+    for (let i = 0; i < baseUpper.length; i += 1) {
+      mapping[baseUpper[i]] = String.fromCodePoint(codepoints.upperStart + i);
+    }
+  }
+
+  if (typeof codepoints.digitStart === 'number') {
+    for (let i = 0; i < baseDigits.length; i += 1) {
+      mapping[baseDigits[i]] = String.fromCodePoint(codepoints.digitStart + i);
+    }
+  }
+
+  return {
+    key,
+    label,
+    mapping,
+  };
+}
+
+const fonts = [
+  createSequentialFont('bold', 'Mathematical Bold', {
+    upperStart: 0x1d400,
+    lowerStart: 0x1d41a,
+    digitStart: 0x1d7ce,
+  }),
+  createSequentialFont('italic', 'Mathematical Italic', {
+    upperStart: 0x1d434,
+    lowerStart: 0x1d44e,
+  }),
+  createSequentialFont('bold_italic', 'Mathematical Bold Italic', {
+    upperStart: 0x1d468,
+    lowerStart: 0x1d482,
+  }),
+  createSequentialFont('sans_serif', 'Mathematical Sans-Serif', {
+    upperStart: 0x1d5a0,
+    lowerStart: 0x1d5ba,
+    digitStart: 0x1d7e2,
+  }),
+  createSequentialFont('sans_serif_bold', 'Mathematical Sans-Serif Bold', {
+    upperStart: 0x1d5d4,
+    lowerStart: 0x1d5ee,
+    digitStart: 0x1d7ec,
+  }),
+  createSequentialFont('monospace', 'Mathematical Monospace', {
+    upperStart: 0x1d670,
+    lowerStart: 0x1d68a,
+    digitStart: 0x1d7f6,
+  }),
+];
+
+const fontMap = new Map(fonts.map(font => [font.key, font]));
+
+function transformWithFont(text, fontKey) {
+  const font = fontMap.get(fontKey);
+  if (!font) {
+    throw new Error(`Unknown font: ${fontKey}`);
+  }
+
+  const { mapping } = font;
+  return Array.from(text).map(char => mapping[char] ?? char).join('');
+}
+
+const fontChoices = fonts.map(font => ({ name: font.label, value: font.key }));
+
+module.exports = {
+  fonts,
+  fontChoices,
+  transformWithFont,
+};


### PR DESCRIPTION
## Summary
- add a /font slash command that replies with a message rendered in the selected decorative style
- centralize sequential Unicode math alphabet mappings to support multiple font choices
- guard against unavailable fonts and excessively long transformed messages when responding

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7cafd57b48331bff47a1bc442839b