### PR TITLE
Allow guild owners to manage judgements and analysis

### DIFF
--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -95,7 +95,7 @@ const categories = {
     { cmd: '/botlook', desc: 'Update the bot avatar, nickname, or bio', perm: 'Bot Owner' },
     { cmd: '/fetchmessage', desc: 'Backfill user messages from a channel for analysis tools', perm: 'Bot Owner' },
     { cmd: '/dmdiag test/role', desc: 'Run DM diagnostics for a member or role', perm: 'Bot Owner' },
-    { cmd: '/givejudgement', desc: 'Grant Judgements directly to a user', perm: 'Bot Owner' },
+    { cmd: '/givejudgement', desc: 'Grant Judgements directly to a user', perm: 'Bot Owner or Guild Owner' },
     { cmd: '/wraith start/stop', desc: 'Create a private spam channel and isolate a member', perm: 'Bot Owner' },
   ],
 };


### PR DESCRIPTION
## Summary
- let guild owners run /givejudgement alongside bot owners and announce the grant publicly
- allow guild owners to target other members with /analysis and add the Toxicity Analysis persona
- refresh help copy to reflect the expanded ownership permissions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7ed279d1c83319824e035e0ce2ce3