### PR TITLE
Improve media cloning and embed colour handling

### DIFF
--- a/src/commands/clone.js
+++ b/src/commands/clone.js
@@ -200,9 +200,12 @@ module.exports = {
             }
             name = name.toLowerCase().replace(/[^a-z0-9_]/g, '_').slice(0, 30) || 'sticker';
 
+            const extensionMatch = sourceUrl?.match(/\.([a-z0-9]+)(?:\?.*)?$/i);
+            const fileExtension = extensionMatch ? extensionMatch[1].toLowerCase() : 'png';
+
             try {
                 const created = await interaction.guild.stickers.create({
-                    file: fileBuffer,
+                    file: { name: `${name}.${fileExtension}`, data: fileBuffer },
                     name,
                     tags: tagsInput,
                     description,

--- a/src/commands/enlarge.js
+++ b/src/commands/enlarge.js
@@ -208,8 +208,8 @@ module.exports = {
         if (!res.ok) throw new Error('Download failed');
         const buf = await res.buffer();
         const attachment = new AttachmentBuilder(buf, { name: fileName });
-        if (acknowledged) return interaction.editReply({ content: url, files: [attachment] });
-        if (channelMsg) return channelMsg.edit({ content: url, files: [attachment] });
+        if (acknowledged) return interaction.editReply({ content: 'Here is the enlarged emoji.', files: [attachment] });
+        if (channelMsg) return channelMsg.edit({ content: 'Here is the enlarged emoji.', files: [attachment] });
         return;
       } catch (err) {
         const msg = `Failed to fetch emoji image. URL: ${url}`;
@@ -252,8 +252,9 @@ module.exports = {
       // Guess extension from URL if possible
       const guessedExt = (urlUsed && (urlUsed.match(/\.([a-z0-9]+)(?:\?.*)?$/i)?.[1] || 'png')) || 'png';
       const attachment = new AttachmentBuilder(buffer, { name: `sticker.${guessedExt}` });
-      if (acknowledged) return interaction.editReply({ content: urlUsed || 'Here is the sticker file:', files: [attachment] });
-      if (channelMsg) return channelMsg.edit({ content: urlUsed || 'Here is the sticker file:', files: [attachment] });
+      const responseContent = 'Here is the enlarged sticker.';
+      if (acknowledged) return interaction.editReply({ content: responseContent, files: [attachment] });
+      if (channelMsg) return channelMsg.edit({ content: responseContent, files: [attachment] });
       return;
     }
 

--- a/src/utils/colorParser.js
+++ b/src/utils/colorParser.js
@@ -1,0 +1,59 @@
+const NAMED_COLOURS = Object.freeze({
+  red: 0xff0000,
+  orange: 0xffa500,
+  yellow: 0xffe600,
+  green: 0x57f287,
+  blue: 0x5865f2,
+  purple: 0x9b59b6,
+  pink: 0xff69b4,
+  white: 0xffffff,
+  black: 0x000000,
+  grey: 0x95a5a6,
+  gray: 0x95a5a6,
+  cyan: 0x00ffff,
+  teal: 0x1abc9c,
+  gold: 0xf1c40f,
+});
+
+function parseColorInput(input, fallback) {
+  if (input == null) {
+    return fallback;
+  }
+
+  if (typeof input === 'number' && Number.isFinite(input)) {
+    return input;
+  }
+
+  if (typeof input !== 'string') {
+    return fallback;
+  }
+
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return fallback;
+  }
+
+  const lower = trimmed.toLowerCase();
+  if (Object.prototype.hasOwnProperty.call(NAMED_COLOURS, lower)) {
+    return NAMED_COLOURS[lower];
+  }
+
+  const hexMatch = lower.match(/^#?([0-9a-f]{3}|[0-9a-f]{6})$/i);
+  if (hexMatch) {
+    const hex = hexMatch[1];
+    if (hex.length === 3) {
+      const expanded = hex.split('').map(ch => ch + ch).join('');
+      return parseInt(expanded, 16);
+    }
+    return parseInt(hex, 16);
+  }
+
+  const intVal = Number.parseInt(trimmed, 10);
+  if (Number.isFinite(intVal)) {
+    return intVal;
+  }
+
+  return fallback;
+}
+
+module.exports = { parseColorInput };


### PR DESCRIPTION
## Summary
- add a reusable colour parser to support named, numeric, and shorthand hex inputs
- harden /embed quick and modal flows with colour parsing, URL validation, and clearer messaging
- update media utilities so emoji/sticker enlargements and sticker cloning return cleaner output

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d86a232afc83318d7205efbd4dd1b9