### PR TITLE
Enforce transparent PNG booster emblems

### DIFF
--- a/src/commands/bremblem.js
+++ b/src/commands/bremblem.js
@@ -9,7 +9,7 @@ module.exports = {
     .addAttachmentOption(option =>
       option
         .setName('image')
-        .setDescription('PNG or JPEG image under 256 KB to use as your emblem')
+        .setDescription('PNG image with a transparent background under 256 KB to use as your emblem')
         .setRequired(false)
     )
     .addBooleanOption(option =>
@@ -43,7 +43,7 @@ module.exports = {
 
     if (!shouldClear && !attachment) {
       return interaction.reply({
-        content: 'Please upload an image or enable the clear option to remove your emblem.',
+        content: 'Please upload a PNG image with a transparent background or enable the clear option to remove your emblem.',
         ephemeral: true,
       });
     }

--- a/tests/boosterRoleManagerImage.test.js
+++ b/tests/boosterRoleManagerImage.test.js
@@ -1,0 +1,26 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { pngSupportsTransparency } = require('../src/utils/boosterRoleManager');
+
+const TRANSPARENT_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGNgAAIAAAUAAXpeqz8AAAAASUVORK5CYII=';
+const OPAQUE_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4//8/AAX+Av4N70a4AAAAAElFTkSuQmCC';
+
+function bufferFromBase64(base64) {
+  return Buffer.from(base64, 'base64');
+}
+
+test('pngSupportsTransparency returns true for PNG with alpha channel', () => {
+  const buffer = bufferFromBase64(TRANSPARENT_BASE64);
+  assert.equal(pngSupportsTransparency(buffer), true);
+});
+
+test('pngSupportsTransparency returns false for PNG without transparency support', () => {
+  const buffer = bufferFromBase64(OPAQUE_BASE64);
+  assert.equal(pngSupportsTransparency(buffer), false);
+});
+
+test('pngSupportsTransparency returns false for non-PNG data', () => {
+  const buffer = Buffer.from('not a png');
+  assert.equal(pngSupportsTransparency(buffer), false);
+});


### PR DESCRIPTION
## Summary
- restrict booster emblems to PNG uploads and verify their transparency before saving
- update the /bremblem command messaging to explain the transparent PNG requirement
- cover the PNG transparency helper with targeted unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d88e5641ac8331a90f78639ede19c6