### PR TITLE
Add autobump command and scheduler for listing bumps

### DIFF
--- a/src/commands/autobump.js
+++ b/src/commands/autobump.js
@@ -1,0 +1,252 @@
+const { SlashCommandBuilder, PermissionsBitField, ChannelType } = require('discord.js');
+const store = require('../utils/autoBumpStore');
+const scheduler = require('../utils/autoBumpScheduler');
+const { getService, getServiceChoices, getDefaultIntervalMs, getDefaultCommand } = require('../utils/autoBumpServices');
+
+const MIN_INTERVAL_MINUTES = 5;
+const MAX_INTERVAL_MINUTES = 24 * 60;
+
+function clampIntervalMinutes(minutes, fallbackMs) {
+  if (Number.isNaN(minutes) || minutes <= 0) {
+    return Math.round((fallbackMs || 60_000) / 60_000);
+  }
+  return Math.min(Math.max(minutes, MIN_INTERVAL_MINUTES), MAX_INTERVAL_MINUTES);
+}
+
+function formatDuration(ms) {
+  if (!ms || !Number.isFinite(ms)) return 'soon';
+  const totalSeconds = Math.max(0, Math.round(ms / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const parts = [];
+  if (hours) parts.push(`${hours}h`);
+  if (minutes) parts.push(`${minutes}m`);
+  if (!parts.length && seconds) parts.push(`${seconds}s`);
+  return parts.length ? parts.join(' ') : 'now';
+}
+
+function formatRelative(targetMs) {
+  if (!targetMs) return 'soon';
+  const diff = targetMs - Date.now();
+  if (diff <= 0) return 'soon';
+  return `in ${formatDuration(diff)}`;
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('autobump')
+    .setDescription('Automatically send bump commands for listing sites')
+    .setDefaultMemberPermissions(PermissionsBitField.Flags.ManageGuild)
+    .setDMPermission(false)
+    .addSubcommand(sub =>
+      sub
+        .setName('add')
+        .setDescription('Create a new bump schedule')
+        .addStringOption(opt =>
+          opt
+            .setName('service')
+            .setDescription('Listing service to bump')
+            .setRequired(true)
+            .addChoices(...getServiceChoices())
+        )
+        .addChannelOption(opt =>
+          opt
+            .setName('channel')
+            .setDescription('Channel to run the bump command in')
+            .addChannelTypes(
+              ChannelType.GuildText,
+              ChannelType.GuildAnnouncement,
+              ChannelType.PublicThread,
+              ChannelType.PrivateThread,
+            )
+        )
+        .addStringOption(opt =>
+          opt
+            .setName('command')
+            .setDescription('Override the command text (defaults per service)')
+            .setMaxLength(2000)
+        )
+        .addIntegerOption(opt =>
+          opt
+            .setName('interval_minutes')
+            .setDescription('Minutes between bumps (defaults per service)')
+            .setMinValue(MIN_INTERVAL_MINUTES)
+            .setMaxValue(MAX_INTERVAL_MINUTES)
+        )
+        .addIntegerOption(opt =>
+          opt
+            .setName('start_after_minutes')
+            .setDescription('Delay before the first bump runs (default 1 minute)')
+            .setMinValue(1)
+            .setMaxValue(12 * 60)
+        )
+        .addBooleanOption(opt =>
+          opt
+            .setName('allow_mentions')
+            .setDescription('Allow mentions in the bump command (default off)')
+        )
+    )
+    .addSubcommand(sub =>
+      sub
+        .setName('remove')
+        .setDescription('Delete a bump schedule')
+        .addIntegerOption(opt =>
+          opt
+            .setName('id')
+            .setDescription('Autobump job ID')
+            .setRequired(true)
+        )
+    )
+    .addSubcommand(sub =>
+      sub
+        .setName('enable')
+        .setDescription('Enable a bump schedule that is currently disabled')
+        .addIntegerOption(opt =>
+          opt
+            .setName('id')
+            .setDescription('Autobump job ID')
+            .setRequired(true)
+        )
+    )
+    .addSubcommand(sub =>
+      sub
+        .setName('disable')
+        .setDescription('Disable a bump schedule without deleting it')
+        .addIntegerOption(opt =>
+          opt
+            .setName('id')
+            .setDescription('Autobump job ID')
+            .setRequired(true)
+        )
+    )
+    .addSubcommand(sub =>
+      sub
+        .setName('list')
+        .setDescription('List configured bump schedules')
+    ),
+
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ content: 'Use this command in a server.', ephemeral: true });
+    }
+
+    const memberPerms = interaction.member?.permissions;
+    if (!memberPerms?.has(PermissionsBitField.Flags.ManageGuild)) {
+      return interaction.reply({ content: 'You need the Manage Server permission to use /autobump.', ephemeral: true });
+    }
+
+    const sub = interaction.options.getSubcommand();
+    const guildId = interaction.guildId;
+
+    if (sub === 'add') {
+      await interaction.deferReply({ ephemeral: true });
+      const serviceKey = interaction.options.getString('service', true);
+      const service = getService(serviceKey);
+      if (!service) {
+        return interaction.editReply({ content: 'Unknown service selected.' });
+      }
+      const channel = interaction.options.getChannel('channel') || interaction.channel;
+      if (!channel || !channel.isTextBased()) {
+        return interaction.editReply({ content: 'Select a text-based channel for bumps.' });
+      }
+
+      let customCommand = interaction.options.getString('command');
+      if (!customCommand || !customCommand.trim()) {
+        customCommand = getDefaultCommand(serviceKey);
+      }
+      if (!customCommand || !customCommand.trim()) {
+        return interaction.editReply({ content: 'Please provide a command for this service.' });
+      }
+      customCommand = customCommand.trim().slice(0, 2000);
+
+      const intervalOverride = interaction.options.getInteger('interval_minutes');
+      const intervalMinutes = intervalOverride
+        ? clampIntervalMinutes(intervalOverride, getDefaultIntervalMs(serviceKey))
+        : clampIntervalMinutes(Math.round(getDefaultIntervalMs(serviceKey) / 60_000), getDefaultIntervalMs(serviceKey));
+      const intervalMs = intervalMinutes * 60 * 1000;
+
+      const startDelayMinutes = interaction.options.getInteger('start_after_minutes');
+      const startAfterMs = startDelayMinutes ? startDelayMinutes * 60 * 1000 : 60 * 1000;
+
+      const allowMentions = interaction.options.getBoolean('allow_mentions') || false;
+
+      const job = await store.addJob(guildId, {
+        channelId: channel.id,
+        service: serviceKey,
+        command: customCommand,
+        intervalMs,
+        allowMentions,
+        startAfterMs,
+      });
+
+      try {
+        await scheduler.startJob(interaction.client, guildId, job);
+      } catch (err) {
+        console.error('Failed to start autobump job immediately:', err);
+      }
+
+      const summary = `${service.name} bump every ${intervalMinutes}m in ${channel}`;
+      return interaction.editReply({ content: `Autobump job #${job.id} created: ${summary}. First bump ${formatRelative(job.nextRunAt)}.` });
+    }
+
+    if (sub === 'remove') {
+      await interaction.deferReply({ ephemeral: true });
+      const id = interaction.options.getInteger('id', true);
+      const removed = await store.removeJob(guildId, id);
+      try { scheduler.stopJob(guildId, id); } catch (_) {}
+      return interaction.editReply({ content: removed ? `Removed autobump job #${id}.` : `Autobump job #${id} not found.` });
+    }
+
+    if (sub === 'enable') {
+      await interaction.deferReply({ ephemeral: true });
+      const id = interaction.options.getInteger('id', true);
+      const job = await store.setEnabled(guildId, id, true);
+      if (!job) {
+        return interaction.editReply({ content: `Autobump job #${id} not found.` });
+      }
+      try { await scheduler.startJob(interaction.client, guildId, job); } catch (_) {}
+      return interaction.editReply({ content: `Autobump job #${id} enabled. Next bump ${formatRelative(job.nextRunAt)}.` });
+    }
+
+    if (sub === 'disable') {
+      await interaction.deferReply({ ephemeral: true });
+      const id = interaction.options.getInteger('id', true);
+      const job = await store.setEnabled(guildId, id, false);
+      if (!job) {
+        return interaction.editReply({ content: `Autobump job #${id} not found.` });
+      }
+      try { scheduler.stopJob(guildId, id); } catch (_) {}
+      return interaction.editReply({ content: `Autobump job #${id} disabled.` });
+    }
+
+    if (sub === 'list') {
+      await interaction.deferReply({ ephemeral: true });
+      const jobs = await store.listJobs(guildId);
+      if (!jobs.length) {
+        return interaction.editReply({ content: 'No autobump jobs configured yet.' });
+      }
+      const now = Date.now();
+      const lines = jobs.map(job => {
+        const service = getService(job.service);
+        const status = job.enabled ? '🟢 ON' : '🔴 OFF';
+        const intervalMinutes = Math.round((Number(job.intervalMs) || getDefaultIntervalMs(job.service)) / 60_000);
+        const next = job.enabled ? formatRelative(job.nextRunAt) : 'paused';
+        const last = job.lastRunAt ? `${formatDuration(now - job.lastRunAt)} ago` : 'never';
+        const base = `#${job.id} ${status} • ${(service?.name || job.service)} • every ${intervalMinutes}m • <#${job.channelId}>`;
+        const extras = [];
+        extras.push(`next ${next}`);
+        extras.push(`last ${last}`);
+        if (job.lastError) extras.push(`⚠️ ${job.lastError}`);
+        if (job.command && job.command !== getDefaultCommand(job.service)) {
+          extras.push(`cmd: ${job.command.slice(0, 60)}`);
+        }
+        return `${base}\n    ${extras.join(' | ')}`;
+      });
+      const content = lines.join('\n');
+      return interaction.editReply({ content: content.slice(0, 1900) });
+    }
+
+    return interaction.reply({ content: 'Unknown subcommand.', ephemeral: true });
+  },
+};

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -35,5 +35,13 @@ module.exports = {
     } catch (e) {
       console.warn('Failed to start auto-post scheduler:', e?.message || e);
     }
+
+    // Start autobump scheduler for listing site bumps
+    try {
+      const bumpScheduler = require('../utils/autoBumpScheduler');
+      await bumpScheduler.startAll(client);
+    } catch (e) {
+      console.warn('Failed to start autobump scheduler:', e?.message || e);
+    }
   },
 };

--- a/src/utils/autoBumpScheduler.js
+++ b/src/utils/autoBumpScheduler.js
@@ -1,0 +1,132 @@
+const { ChannelType } = require('discord.js');
+const store = require('./autoBumpStore');
+const { getService, getDefaultCommand, getDefaultIntervalMs } = require('./autoBumpServices');
+
+const timers = new Map();
+const MIN_DELAY_MS = 5_000;
+const FAILURE_RETRY_MINUTES = 15;
+
+function key(guildId, jobId) {
+  return `${guildId}:${jobId}`;
+}
+
+function stopJob(guildId, jobId) {
+  const k = key(guildId, jobId);
+  const timer = timers.get(k);
+  if (timer) {
+    clearTimeout(timer);
+    timers.delete(k);
+  }
+}
+
+function computeDelay(job) {
+  const now = Date.now();
+  if (job.nextRunAt && job.nextRunAt > now) {
+    return Math.max(MIN_DELAY_MS, job.nextRunAt - now);
+  }
+  return Math.max(MIN_DELAY_MS, Number(job.intervalMs) || getDefaultIntervalMs(job.service));
+}
+
+function schedule(client, guildId, job) {
+  stopJob(guildId, job.id);
+  if (!job.enabled) return;
+  const delay = computeDelay(job);
+  const k = key(guildId, job.id);
+  const timer = setTimeout(async () => {
+    try {
+      const fresh = await store.getJob(guildId, job.id);
+      if (!fresh || !fresh.enabled) {
+        timers.delete(k);
+        return;
+      }
+      await runJob(client, guildId, fresh);
+    } catch (err) {
+      console.error(`Autobump job ${guildId}/${job.id} crashed:`, err);
+      await store.markRunFailure(guildId, job.id, FAILURE_RETRY_MINUTES * 60 * 1000, err?.message);
+      const updated = await store.getJob(guildId, job.id);
+      if (updated && updated.enabled) schedule(client, guildId, updated);
+      return;
+    }
+    const updated = await store.getJob(guildId, job.id);
+    if (updated && updated.enabled) schedule(client, guildId, updated);
+  }, delay);
+  timers.set(k, timer);
+}
+
+async function runJob(client, guildId, job) {
+  const service = getService(job.service);
+  const content = String(job.command || service?.defaultCommand || getDefaultCommand(job.service) || '').trim();
+  if (!content) {
+    await store.markRunFailure(guildId, job.id, FAILURE_RETRY_MINUTES * 60 * 1000, 'No command configured.');
+    return;
+  }
+
+  const guild = client.guilds.cache.get(guildId) || await client.guilds.fetch(guildId).catch(() => null);
+  if (!guild) {
+    await store.markRunFailure(guildId, job.id, FAILURE_RETRY_MINUTES * 60 * 1000, 'Guild unavailable.');
+    return;
+  }
+
+  let channel = guild.channels.cache.get(job.channelId);
+  if (!channel) {
+    try {
+      channel = await guild.channels.fetch(job.channelId);
+    } catch (_) {
+      channel = null;
+    }
+  }
+
+  if (!channel) {
+    await store.markRunFailure(guildId, job.id, FAILURE_RETRY_MINUTES * 60 * 1000, 'Channel not found.');
+    return;
+  }
+
+  if (!channel.isTextBased() || channel.type === ChannelType.GuildVoice) {
+    await store.markRunFailure(guildId, job.id, FAILURE_RETRY_MINUTES * 60 * 1000, 'Channel not text-based.');
+    return;
+  }
+
+  try {
+    await channel.send({
+      content,
+      allowedMentions: job.allowMentions ? undefined : { parse: [] },
+    });
+    await store.markRunSuccess(guildId, job.id);
+  } catch (err) {
+    await store.markRunFailure(guildId, job.id, FAILURE_RETRY_MINUTES * 60 * 1000, err?.message || 'Failed to send command.');
+  }
+}
+
+async function startJob(client, guildId, job) {
+  const fresh = job || await store.getJob(guildId, job?.id);
+  if (!fresh) return;
+  schedule(client, guildId, fresh);
+}
+
+async function reloadGuild(client, guildId) {
+  for (const timerKey of Array.from(timers.keys())) {
+    if (timerKey.startsWith(`${guildId}:`)) {
+      clearTimeout(timers.get(timerKey));
+      timers.delete(timerKey);
+    }
+  }
+  const jobs = await store.listJobs(guildId);
+  for (const job of jobs) {
+    if (job.enabled) schedule(client, guildId, job);
+  }
+}
+
+async function startAll(client) {
+  const guildIds = Array.from(client.guilds.cache.keys());
+  for (const gid of guildIds) {
+    // eslint-disable-next-line no-await-in-loop
+    await reloadGuild(client, gid);
+  }
+}
+
+module.exports = {
+  startAll,
+  reloadGuild,
+  startJob,
+  stopJob,
+};

--- a/src/utils/autoBumpServices.js
+++ b/src/utils/autoBumpServices.js
@@ -1,0 +1,72 @@
+const SERVICE_DEFINITIONS = [
+  {
+    key: 'disboard',
+    name: 'Disboard',
+    defaultCommand: '!d bump',
+    defaultIntervalMinutes: 120,
+    description: 'Sends `!d bump` for the Disboard bot every 2 hours (Disboard cooldown).',
+  },
+  {
+    key: 'discadia',
+    name: 'Discadia',
+    defaultCommand: '!bump',
+    defaultIntervalMinutes: 120,
+    description: 'Sends the Discadia bump command (default `!bump`) every 2 hours.',
+  },
+  {
+    key: 'discords',
+    name: 'Discords.com',
+    defaultCommand: '!bump',
+    defaultIntervalMinutes: 120,
+    description: 'Triggers the discords.com bump command (default `!bump`) every 2 hours.',
+  },
+  {
+    key: 'disforge',
+    name: 'Disforge',
+    defaultCommand: '!bump',
+    defaultIntervalMinutes: 60,
+    description: 'Sends the Disforge bump command (default `!bump`) every 60 minutes.',
+  },
+  {
+    key: 'voidbots',
+    name: 'Void Bots',
+    defaultCommand: '!bump',
+    defaultIntervalMinutes: 60,
+    description: 'Sends the Void Bots bump command (default `!bump`) every 60 minutes.',
+  },
+  {
+    key: 'custom',
+    name: 'Custom / Other',
+    defaultCommand: '',
+    defaultIntervalMinutes: 120,
+    description: 'Use this for other listing sites — provide your own command and interval.',
+  },
+];
+
+function getService(key) {
+  return SERVICE_DEFINITIONS.find(service => service.key === key) || null;
+}
+
+function getServiceChoices() {
+  return SERVICE_DEFINITIONS.map(service => ({ name: service.name, value: service.key }));
+}
+
+function getDefaultIntervalMs(key) {
+  const service = getService(key);
+  if (!service) return 120 * 60 * 1000;
+  const minutes = Number(service.defaultIntervalMinutes) || 120;
+  return Math.max(60_000, minutes * 60 * 1000);
+}
+
+function getDefaultCommand(key) {
+  const service = getService(key);
+  return service?.defaultCommand || '';
+}
+
+module.exports = {
+  SERVICE_DEFINITIONS,
+  getService,
+  getServiceChoices,
+  getDefaultIntervalMs,
+  getDefaultCommand,
+};

--- a/src/utils/autoBumpStore.js
+++ b/src/utils/autoBumpStore.js
@@ -1,0 +1,201 @@
+const fs = require('fs/promises');
+const { ensureFile, resolveDataPath, writeJson } = require('./dataDir');
+const { getDefaultIntervalMs, getDefaultCommand } = require('./autoBumpServices');
+
+const STORE_FILE = 'autobump.json';
+const MIN_INTERVAL_MS = 60_000;
+const DEFAULT_START_DELAY_MS = 60_000;
+
+let cache = null;
+let loadPromise = null;
+let saveTimeout = null;
+
+function getDataFile() {
+  return resolveDataPath(STORE_FILE);
+}
+
+async function ensureLoaded() {
+  if (cache) return;
+  if (loadPromise) {
+    await loadPromise;
+    return;
+  }
+  loadPromise = (async () => {
+    try {
+      await ensureFile(STORE_FILE, '{}');
+      const raw = await fs.readFile(getDataFile(), 'utf8').catch(err => {
+        if (err.code === 'ENOENT') return '{}';
+        throw err;
+      });
+      cache = JSON.parse(raw || '{}');
+    } catch (err) {
+      console.error('Failed to load autobump store:', err);
+      cache = {};
+    } finally {
+      loadPromise = null;
+    }
+  })();
+  await loadPromise;
+}
+
+function schedulePersist() {
+  if (saveTimeout) return;
+  saveTimeout = setTimeout(async () => {
+    saveTimeout = null;
+    try {
+      const safe = cache && typeof cache === 'object' ? cache : {};
+      await writeJson(STORE_FILE, safe);
+    } catch (err) {
+      console.error('Failed to persist autobump store:', err);
+    }
+  }, 100);
+}
+
+function normalizeJob(job) {
+  if (!job) return job;
+  job.channelId = String(job.channelId || '');
+  job.service = String(job.service || 'custom');
+  job.command = String(job.command || '').slice(0, 2000);
+  job.intervalMs = Math.max(MIN_INTERVAL_MS, Number(job.intervalMs) || getDefaultIntervalMs(job.service));
+  job.allowMentions = !!job.allowMentions;
+  job.enabled = !!job.enabled;
+  job.lastRunAt = typeof job.lastRunAt === 'number' ? job.lastRunAt : null;
+  job.nextRunAt = typeof job.nextRunAt === 'number' ? job.nextRunAt : null;
+  job.lastError = typeof job.lastError === 'string' ? job.lastError.slice(0, 300) : null;
+  job.createdAt = typeof job.createdAt === 'number' ? job.createdAt : Date.now();
+  if (!job.command) job.command = getDefaultCommand(job.service) || '';
+  return job;
+}
+
+function getGuildSync(guildId) {
+  if (!cache[guildId]) {
+    cache[guildId] = { nextId: 1, jobs: [] };
+    schedulePersist();
+  }
+  const cfg = cache[guildId];
+  if (!cfg.nextId || typeof cfg.nextId !== 'number') cfg.nextId = 1;
+  if (!Array.isArray(cfg.jobs)) cfg.jobs = [];
+  cfg.jobs = cfg.jobs.map(normalizeJob);
+  return cfg;
+}
+
+async function getGuild(guildId) {
+  await ensureLoaded();
+  return getGuildSync(guildId);
+}
+
+async function listJobs(guildId) {
+  const cfg = await getGuild(guildId);
+  return cfg.jobs.map(job => ({ ...job }));
+}
+
+async function getJob(guildId, id) {
+  const cfg = await getGuild(guildId);
+  const job = cfg.jobs.find(j => j.id === Number(id));
+  return job ? { ...job } : null;
+}
+
+function withMutatedJob(cfg, id, mutator) {
+  const job = cfg.jobs.find(j => j.id === Number(id));
+  if (!job) return null;
+  mutator(job);
+  normalizeJob(job);
+  schedulePersist();
+  return { ...job };
+}
+
+async function addJob(guildId, options) {
+  const {
+    channelId,
+    service,
+    command,
+    intervalMs,
+    allowMentions = false,
+    startAfterMs = DEFAULT_START_DELAY_MS,
+  } = options;
+  const cfg = await getGuild(guildId);
+  const id = cfg.nextId++;
+  const job = normalizeJob({
+    id,
+    channelId,
+    service,
+    command,
+    intervalMs: Math.max(MIN_INTERVAL_MS, Number(intervalMs) || getDefaultIntervalMs(service)),
+    allowMentions: !!allowMentions,
+    enabled: true,
+    createdAt: Date.now(),
+    lastRunAt: null,
+    nextRunAt: Date.now() + Math.max(MIN_INTERVAL_MS, Number(startAfterMs) || DEFAULT_START_DELAY_MS),
+    lastError: null,
+  });
+  cfg.jobs.push(job);
+  schedulePersist();
+  return { ...job };
+}
+
+async function removeJob(guildId, id) {
+  const cfg = await getGuild(guildId);
+  const before = cfg.jobs.length;
+  cfg.jobs = cfg.jobs.filter(j => j.id !== Number(id));
+  const removed = cfg.jobs.length !== before;
+  if (removed) schedulePersist();
+  return removed;
+}
+
+async function setEnabled(guildId, id, enabled) {
+  const cfg = await getGuild(guildId);
+  return withMutatedJob(cfg, id, job => {
+    job.enabled = !!enabled;
+    if (job.enabled) {
+      job.nextRunAt = Date.now() + Math.max(MIN_INTERVAL_MS, job.intervalMs);
+      job.lastError = null;
+    } else {
+      job.nextRunAt = null;
+    }
+  });
+}
+
+async function updateCommand(guildId, id, command) {
+  const cfg = await getGuild(guildId);
+  return withMutatedJob(cfg, id, job => {
+    job.command = String(command || '').slice(0, 2000);
+  });
+}
+
+async function updateInterval(guildId, id, intervalMs) {
+  const cfg = await getGuild(guildId);
+  return withMutatedJob(cfg, id, job => {
+    job.intervalMs = Math.max(MIN_INTERVAL_MS, Number(intervalMs) || job.intervalMs);
+  });
+}
+
+async function markRunSuccess(guildId, id) {
+  const cfg = await getGuild(guildId);
+  return withMutatedJob(cfg, id, job => {
+    const now = Date.now();
+    job.lastRunAt = now;
+    job.nextRunAt = now + Math.max(MIN_INTERVAL_MS, job.intervalMs);
+    job.lastError = null;
+  });
+}
+
+async function markRunFailure(guildId, id, delayMs, errorMessage) {
+  const cfg = await getGuild(guildId);
+  return withMutatedJob(cfg, id, job => {
+    const now = Date.now();
+    job.lastError = errorMessage ? String(errorMessage).slice(0, 300) : 'Unknown error';
+    job.nextRunAt = now + Math.max(MIN_INTERVAL_MS, Number(delayMs) || job.intervalMs || MIN_INTERVAL_MS);
+  });
+}
+
+module.exports = {
+  listJobs,
+  getJob,
+  addJob,
+  removeJob,
+  setEnabled,
+  updateCommand,
+  updateInterval,
+  markRunSuccess,
+  markRunFailure,
+};


### PR DESCRIPTION
## Summary
- add an `/autobump` slash command to create, manage, and list scheduled bump jobs for server listing services
- persist bump job configuration in a dedicated store and process them with a resilient scheduler
- start the autobump scheduler when the bot becomes ready and ship presets for popular bump services

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d893cc56c88331a08fa3f9cca47be8