### PR TITLE
Rename voiceauto command to transriptconfig

### DIFF
--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -36,7 +36,7 @@ const categories = {
     { cmd: '/logconfig', desc: 'Review the status of moderation, security, and channel logging', perm: 'Manage Server' },
     { cmd: '/antinuke config', desc: 'Configure anti-nuke safeguards and view their current status', perm: 'Manage Server' },
     { cmd: '/joins leaderboard/user/setlog/backfill', desc: 'Track join/leave stats and import historical logs', perm: 'Manage Server' },
-    { cmd: '/voiceauto enable/disable/status', desc: 'Enable automatic voice transcription in chosen channels', perm: 'Manage Server' },
+    { cmd: '/transriptconfig enable/disable/status', desc: 'Enable automatic voice transcription in chosen channels', perm: 'Manage Server' },
     { cmd: '/securityreport', desc: 'Report members frequently triggering permission or hierarchy issues', perm: 'Manage Server' },
   ],
   'Server Setup & Messaging': [

--- a/src/commands/transriptconfig.js
+++ b/src/commands/transriptconfig.js
@@ -13,7 +13,7 @@ function isTextLike(channel) {
 
 module.exports = {
   data: new SlashCommandBuilder()
-    .setName('voiceauto')
+    .setName('transriptconfig')
     .setDescription('Configure automatic voice-message transcription')
     .addSubcommand(sub =>
       sub.setName('enable')


### PR DESCRIPTION
## Summary
- rename the automatic voice transcription slash command to `/transriptconfig`
- update help documentation to reflect the new command name

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8983b68cc8331b616848236b03adc