### PR TITLE
Fix panelremove command export

### DIFF
--- a/src/commands/panelremove.js
+++ b/src/commands/panelremove.js
@@ -1,18 +1,19 @@
 const { SlashCommandBuilder, PermissionsBitField } = require('discord.js');
 const ticketStore = require('../utils/ticketStore');
 
-data: new SlashCommandBuilder()
-  .setName('panelremove')
-  .setDescription('Delete a ticket panel template')
-  .addStringOption(option =>
-    option
-      .setName('panel')
-      .setDescription('Panel name or ID to remove')
-      .setRequired(true)
-  )
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('panelremove')
+    .setDescription('Delete a ticket panel template')
+    .addStringOption(option =>
+      option
+        .setName('panel')
+        .setDescription('Panel name or ID to remove')
+        .setRequired(true)
+    ),
 
-async execute(interaction) {
-  if (!interaction.inGuild()) {
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
       return interaction.reply({ content: 'Use this command inside a server.', ephemeral: true });
     }
 


### PR DESCRIPTION
## Summary
- wrap the panelremove command definition in a module export so deploy-commands.js can load it

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8a1ce1d04833187572bd185dc433e