### PR TITLE
Fix panel setup module export syntax error

### DIFF
--- a/src/commands/panelsetup.js
+++ b/src/commands/panelsetup.js
@@ -95,6 +95,7 @@ module.exports = {
         .addChannelTypes(ChannelType.GuildText, ChannelType.GuildAnnouncement, ChannelType.GuildForum, ChannelType.GuildCategory)
         .setRequired(false)
     )
+  ,
 
   async execute(interaction) {
     if (!interaction.inGuild()) {


### PR DESCRIPTION
## Summary
- add the missing comma between the command builder and execute handler in panelsetup command to restore valid module syntax

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8a332ac04833193ab364a7f9eda0f